### PR TITLE
fix: ambient sound is not active when silent and looping after change…

### DIFF
--- a/regamedll/dlls/sound.cpp
+++ b/regamedll/dlls/sound.cpp
@@ -182,12 +182,12 @@ void CAmbientGeneric::Restart()
 	pev->nextthink = gpGlobals->time + 0.1f;
 
 	if (!(pev->spawnflags & SF_AMBIENT_SOUND_NOT_LOOPING))
-	{
 		m_fLooping = TRUE;
-		m_fActive = TRUE;
-	}
 	else
 		m_fLooping = FALSE;
+
+	if (!(pev->spawnflags & SF_AMBIENT_SOUND_START_SILENT))
+		m_fActive = TRUE;
 
 	if (m_fActive)
 	{


### PR DESCRIPTION
If you launch a map, var m_fActive of ambient_sound will be TRUE. But this is incorrect, if entity has silent flag