### PR TITLE
Fix buy bots sec ammo

### DIFF
--- a/regamedll/dlls/bot/states/cs_bot_buy.cpp
+++ b/regamedll/dlls/bot/states/cs_bot_buy.cpp
@@ -462,17 +462,26 @@ void BuyState::OnUpdate(CCSBot *me)
 			me->ClientCommand("vesthelm");
 			me->ClientCommand("vest");
 
-			// pistols - if we have no preferred pistol, buy at random
-			if (TheCSBots()->AllowPistols() && !me->GetProfile()->HasPistolPreference())
+			if (TheCSBots()->AllowPistols()
+#ifndef REGAMEDLL_FIXES
+				&& !me->GetProfile()->HasPistolPreference()
+#endif
+			)
 			{
 				if (m_buyPistol)
 				{
-					int which = RANDOM_LONG(0, MAX_BUY_WEAPON_SECONDARY - 1);
+#ifdef REGAMEDLL_FIXES
+					// pistols - if we have no preferred pistol, buy at random
+					if (!me->GetProfile()->HasPistolPreference())
+#endif
+					{
+						int which = RANDOM_LONG(0, MAX_BUY_WEAPON_SECONDARY - 1);
 
-					if (me->m_iTeam == TERRORIST)
-						me->ClientCommand(secondaryWeaponBuyInfoT[which].buyAlias);
-					else
-						me->ClientCommand(secondaryWeaponBuyInfoCT[which].buyAlias);
+						if (me->m_iTeam == TERRORIST)
+							me->ClientCommand(secondaryWeaponBuyInfoT[which].buyAlias);
+						else
+							me->ClientCommand(secondaryWeaponBuyInfoCT[which].buyAlias);
+					}
 
 					// only buy one pistol
 					m_buyPistol = false;


### PR DESCRIPTION
bots can't buy sec ammo if preferred pistol (ex. "WeaponPreference = deagle" in BotProfile.db)
