### PR TITLE
Team Say refactory/enhancement

### DIFF
--- a/regamedll/dlls/client.cpp
+++ b/regamedll/dlls/client.cpp
@@ -841,6 +841,12 @@ void Host_Say(edict_t *pEntity, BOOL teamonly)
 	char *pszConsoleFormat = nullptr;
 	bool consoleUsesPlaceName = false;
 
+#ifdef REGAMEDLL_ADD
+	// there's no team on FFA mode
+	if (teamonly && CSGameRules()->IsFreeForAll() && (pPlayer->m_iTeam == CT || pPlayer->m_iTeam == TERRORIST))
+		teamonly = FALSE; 
+#endif
+
 	// team only
 	if (teamonly)
 	{

--- a/regamedll/dlls/client.cpp
+++ b/regamedll/dlls/client.cpp
@@ -1001,7 +1001,13 @@ void Host_Say(edict_t *pEntity, BOOL teamonly)
 		if (gpGlobals->deathmatch != 0.0f && CSGameRules()->m_VoiceGameMgr.PlayerHasBlockedPlayer(pReceiver, pPlayer))
 			continue;
 
-		if (teamonly && pReceiver->m_iTeam != pPlayer->m_iTeam)
+		if (teamonly 
+#ifdef REGAMEDLL_FIXES
+			&& CSGameRules()->PlayerRelationship(pPlayer, pReceiver) != GR_TEAMMATE
+#else
+			&& pReceiver->m_iTeam != pPlayer->m_iTeam
+#endif
+			)
 			continue;
 
 		if (
@@ -1014,7 +1020,13 @@ void Host_Say(edict_t *pEntity, BOOL teamonly)
 				continue;
 		}
 
-		if ((pReceiver->m_iIgnoreGlobalChat == IGNOREMSG_ENEMY && pReceiver->m_iTeam == pPlayer->m_iTeam)
+		if ((pReceiver->m_iIgnoreGlobalChat == IGNOREMSG_ENEMY 
+#ifdef REGAMEDLL_FIXES
+				&& CSGameRules()->PlayerRelationship(pPlayer, pReceiver) == GR_TEAMMATE
+#else
+				&& pReceiver->m_iTeam == pPlayer->m_iTeam
+#endif
+				)
 			|| pReceiver->m_iIgnoreGlobalChat == IGNOREMSG_NONE)
 		{
 			MESSAGE_BEGIN(MSG_ONE, gmsgSayText, nullptr, pReceiver->pev);


### PR DESCRIPTION
## Purpose
Avoid unnecessary use of say_team in FFA mode. Only for CT and T, Spectators can still use say_team.
Fix ignoremsg command behaviour in FFA mode (you can still see "enemies" message)

## Approach
Change Host_Say's teamonly parameter local value to make say_team behaviour work like a simple say message.
Use CSGameRules::PlayerRelationship function instead of directly checking team indexes