### PR TITLE
Don't check the number of spawns in deathmatch

### DIFF
--- a/regamedll/dlls/multiplay_gamerules.cpp
+++ b/regamedll/dlls/multiplay_gamerules.cpp
@@ -2146,6 +2146,19 @@ LINK_HOOK_CLASS_CUSTOM_CHAIN(BOOL, CHalfLifeMultiplay, CSGameRules, TeamFull, (i
 
 BOOL EXT_FUNC CHalfLifeMultiplay::__API_HOOK(TeamFull)(int team_id)
 {
+#ifdef REGAMEDLL_ADD
+	if(forcerespawn.value > 0.0f) {
+		switch(team_id) {
+		case TERRORIST:
+			return m_iSpawnPointCount_Terrorist == 0;
+		case CT:
+			return m_iSpawnPointCount_CT == 0;
+		default:
+			return FALSE;
+		}
+	}
+#endif
+
 	switch (team_id)
 	{
 	case TERRORIST:


### PR DESCRIPTION
## Purpose
When selecting team, the game dll checkes for the number of spawns available in that team.

This doesn't make sense in deathmatch mode (mp_forcerespawn > 0), where you simply do not need N spawns to spawn N players, because they can spawn and respawn at any time.

## Approach
When the deathmatch mode is active, the check is simplified. It passes if there is at least one spawn point available for that team.
