### PR TITLE
Improve SelectDefaultTeam() logic

### DIFF
--- a/regamedll/dlls/multiplay_gamerules.cpp
+++ b/regamedll/dlls/multiplay_gamerules.cpp
@@ -5112,6 +5112,16 @@ TeamName CHalfLifeMultiplay::SelectDefaultTeam()
 		team = CT;
 	}
 	// Choose the team that's losing
+#ifdef REGAMEDLL_ADD
+	else if (m_iNumConsecutiveTerroristLoses > 0)
+	{
+		team = TERRORIST;
+	}
+	else if (m_iNumConsecutiveCTLoses > 0)
+	{
+		team = CT;
+	}
+#else
 	else if (m_iNumTerroristWins < m_iNumCTWins)
 	{
 		team = TERRORIST;
@@ -5120,6 +5130,7 @@ TeamName CHalfLifeMultiplay::SelectDefaultTeam()
 	{
 		team = CT;
 	}
+#endif
 	else
 	{
 		// Teams and scores are equal, pick a random team


### PR DESCRIPTION
a small change in the logic in multiplay_gamerules.cpp SelectDefaultTeam() regarding the selection of a priority team for a player.

In the case of equal numbers of players in teams, the player is selected a team based on the number of victories of the teams. However, this does not always work correctly  Pr: when the map is played for a long time (it can be only dust2, pool_day, etc..) the map changes rarely, the score in the teams can go over 1000+ and the difference between the teams can be, for example, 300, in fact, this method becomes useless because the priority will always work in one direction, even if the players have been different for a long time. I suggest checking the number of consecutive wins, so we can more accurately determine which team will be stronger.
