### PR TITLE
CBasePlayerWeapon::IsPistol virtual decl fix

### DIFF
--- a/regamedll/dlls/weapons.cpp
+++ b/regamedll/dlls/weapons.cpp
@@ -628,6 +628,7 @@ void CBasePlayerItem::DefaultTouch(CBaseEntity *pOther)
 #else
 		!IsSecondaryWeapon(m_iId)
 #endif
+
 		)
 	{
 		return;
@@ -1130,7 +1131,11 @@ void EXT_FUNC CBasePlayerWeapon::__API_HOOK(ItemPostFrame)()
 		m_fFireOnEmpty = FALSE;
 
 		// if it's a pistol then set the shots fired to 0 after the player releases a button
+#ifdef REGAMEDLL_FIXES
+		if (IsPistol())
+#else
 		if (IsSecondaryWeapon(m_iId))
+#endif
 		{
 			m_iShotsFired = 0;
 		}

--- a/regamedll/dlls/weapons.h
+++ b/regamedll/dlls/weapons.h
@@ -379,6 +379,9 @@ public:
 	virtual void RetireWeapon();
 	virtual BOOL ShouldWeaponIdle() { return FALSE; }
 	virtual BOOL UseDecrement() { return FALSE; }
+#ifdef REGAMEDLL_FIXES
+	virtual BOOL IsPistol() { return FALSE; }
+#endif
 
 public:
 	BOOL AddPrimaryAmmo(int iCount, char *szName, int iMaxClip, int iMaxCarry);
@@ -394,7 +397,9 @@ public:
 	float GetNextAttackDelay(float delay);
 	float GetNextAttackDelay2(float delay);
 	bool HasSecondaryAttack();
+#ifndef REGAMEDLL_FIXES
 	BOOL IsPistol() { return (m_iId == WEAPON_USP || m_iId == WEAPON_GLOCK18 || m_iId == WEAPON_P228 || m_iId == WEAPON_DEAGLE || m_iId == WEAPON_ELITE || m_iId == WEAPON_FIVESEVEN); }
+#endif
 	void SetPlayerShieldAnim();
 	void ResetPlayerShieldAnim();
 	bool ShieldSecondaryFire(int iUpAnim, int iDownAnim);
@@ -990,15 +995,9 @@ public:
 		return FALSE;
 	#endif
 	}
-	virtual BOOL IsPistol()
-	{
-	#ifdef REGAMEDLL_FIXES
-		return FALSE;
-	#else
-		// TODO: why the object flashbang is IsPistol?
-		return TRUE;
-	#endif
-	}
+#ifndef REGAMEDLL_FIXES
+	virtual BOOL IsPistol() { return TRUE; } // TODO: why the object flashbang is IsPistol?
+#endif
 
 #ifdef REGAMEDLL_API
 	BOOL CanDeploy_OrigFunc();
@@ -1221,6 +1220,7 @@ public:
 	virtual int iItemSlot() { return KNIFE_SLOT; }
 	virtual void PrimaryAttack();
 	virtual void SecondaryAttack();
+	virtual void WeaponIdle();
 	virtual BOOL UseDecrement()
 	{
 	#ifdef CLIENT_WEAPONS
@@ -1229,7 +1229,6 @@ public:
 		return FALSE;
 	#endif
 	}
-	virtual void WeaponIdle();
 
 public:
 	void EXPORT SwingAgain();


### PR DESCRIPTION
## Purpose
IsPistol function was declared non-virtual on base class CBasePlayerWeapon, but virtual on child classes (pistol ones)

## Approach
Make IsPistol virtual, which wont break vtable offsets since IsPistol is already the last virtual function in the table. (need an extra opinion here)

## Extra
m_iShotsFired on WeaponIdle is resetted whenever weapon is a Pistol, which was decided by IsSecondaryWeapon (weapon id checking) - now it is IsPistol, which is class-specific.
