### PR TITLE
Use AddPoints when exploding/defusing C4 bombs to properly update scoreboard

### DIFF
--- a/regamedll/dlls/ggrenade.cpp
+++ b/regamedll/dlls/ggrenade.cpp
@@ -1104,11 +1104,19 @@ void CGrenade::__API_HOOK(DefuseBombEnd)(CBasePlayer *pPlayer, bool bDefused)
 			CSGameRules()->m_bBombDefused = true;
 			CSGameRules()->CheckWinConditions();
 
+			int frags;
+
+			// give the defuser credit for defusing the bomb
 #ifdef REGAMEDLL_ADD
-				m_pBombDefuser->pev->frags += (int)give_c4_frags.value;
+			frags = (int)give_c4_frags.value;
 #else
-				// give the defuser credit for defusing the bomb
-				m_pBombDefuser->pev->frags += 3.0f;
+			frags = 3;
+#endif
+
+#ifdef REGAMEDLL_FIXES
+			m_pBombDefuser->AddPoints(frags, TRUE);
+#else
+			m_pBombDefuser->pev->frags += frags;
 #endif
 
 			MESSAGE_BEGIN(MSG_ALL, gmsgBombPickup);
@@ -1472,10 +1480,16 @@ void CGrenade::C4Think()
 		CBasePlayer *pBombOwner = CBasePlayer::Instance(pev->owner);
 		if (pBombOwner)
 		{
+			int frags;
 #ifdef REGAMEDLL_ADD
-			pBombOwner->pev->frags += (int)give_c4_frags.value;
+			frags = (int)give_c4_frags.value;
 #else
-			pBombOwner->pev->frags += 3.0f;
+			frags = 3;
+#endif
+#ifdef REGAMEDLL_FIXES
+			pBombOwner->AddPoints(frags, TRUE);
+#else
+			pBombOwner->pev->frags += frags;
 #endif
 		}
 


### PR DESCRIPTION
## Purpose
Implement AddPoints for awarding frags after the C4 explodes or is defused. Currently, when a round is won, players need to wait until the next round to see their final score after successfully planting or defusing. With the integration of `mp_round_restart_delay`, the round ending can last longer, providing an important window for a scoreboard update.

## Approach
Change frag incrementing inside `CGrenade::C4Think` and `CGrenade::DefuseBombEnd` to use AddPoints (which is currently unused) instead of directly incrementing the member variable.

## Extras
This also allows better handling of frag awarding by hooking the (virtual) AddPoints method, as used by AMXX's hamsandwich module.

Note: In AddPoints, we allow negative scores because mp_give_c4_frags can be negative. This is not particularly important, but it is worth mentioning for completeness.