### PR TITLE
Optimize TraceBleed to skip unnecessary TraceLine calls

### DIFF
--- a/regamedll/dlls/cbase.cpp
+++ b/regamedll/dlls/cbase.cpp
@@ -1541,7 +1541,7 @@ void CBaseEntity::TraceBleed(float flDamage, Vector vecDir, TraceResult *ptr, in
 	{
 #ifdef REGAMEDLL_FIXES
 		// early flip-coin, don't waste trace resources
-		if (!RANDOM_LONG(0, 2))
+		if (RANDOM_LONG(0, 2) != 0)
 			continue; 
 #endif
 		// trace in the opposite direction the shot came from (the direction the shot is going)

--- a/regamedll/dlls/cbase.cpp
+++ b/regamedll/dlls/cbase.cpp
@@ -1539,6 +1539,11 @@ void CBaseEntity::TraceBleed(float flDamage, Vector vecDir, TraceResult *ptr, in
 
 	for (i = 0; i < cCount; i++)
 	{
+#ifdef REGAMEDLL_FIXES
+		// early flip-coin, don't waste trace resources
+		if (!RANDOM_LONG(0, 2))
+			continue; 
+#endif
 		// trace in the opposite direction the shot came from (the direction the shot is going)
 		vecTraceDir = vecDir * -1.0f;
 
@@ -1549,7 +1554,9 @@ void CBaseEntity::TraceBleed(float flDamage, Vector vecDir, TraceResult *ptr, in
 		UTIL_TraceLine(ptr->vecEndPos, ptr->vecEndPos + vecTraceDir * -172.0f, ignore_monsters, ENT(pev), &Bloodtr);
 		if (Bloodtr.flFraction != 1.0f)
 		{
+#ifndef REGAMEDLL_FIXES
 			if (!RANDOM_LONG(0, 2))
+#endif
 			{
 				UTIL_BloodDecalTrace(&Bloodtr, BloodColor());
 			}


### PR DESCRIPTION
## Purpose
Optimize `TraceBleed`, which is called when a player is shot, by reducing unnecessary `TraceLine` calls for blood decal placement. In high-fire-rate modded servers (e.g., zombie mods), this can otherwise consume unnecessary resources.

## Approach
Move the 1/3 probability check to the start of the loop in `TraceBleed` and continue early when it fails, avoiding the cost of computing jitter and calling `TraceLine` in those cases.
