### PR TITLE
Enable shield HUD pickup icon via WeaponList/WeapPickup

### DIFF
--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -3412,7 +3412,23 @@ void EXT_FUNC CBasePlayer::__API_HOOK(GiveShield)(bool bDeploy)
 		}
 	}
 
-#ifndef REGAMEDLL_FIXES
+#ifdef REGAMEDLL_FIXES
+	MESSAGE_BEGIN(MSG_ONE, gmsgWeaponList, nullptr, pev);
+		WRITE_STRING("weapon_shieldgun");
+		WRITE_BYTE(-1); // PrimaryAmmoID
+		WRITE_BYTE(-1); // PrimaryAmmoMaxAmount
+		WRITE_BYTE(-1); // SecondaryAmmoID
+		WRITE_BYTE(-1); // SecondaryAmmoMaxAmount
+		WRITE_BYTE(0); // SlotID (0...N)
+		WRITE_BYTE(0); // NumberInSlot (1...N)
+		WRITE_BYTE(0); // WeaponID
+		WRITE_BYTE(0); // Flags
+	MESSAGE_END();
+
+	MESSAGE_BEGIN(MSG_ONE, gmsgWeapPickup, nullptr, pev);
+		WRITE_BYTE(0); // WeaponID
+	MESSAGE_END();
+#else
 	// NOTE: Moved above, because CC4::Deploy can reset hitbox of shield
 	pev->gamestate = HITGROUP_SHIELD_ENABLED;
 #endif


### PR DESCRIPTION
## Purpose
Enable the unused shield HUD icon in CS 1.6. Unlike weapons, the shield is not normally sent through the `WeaponList` message, so its history icon never appears on pickup. However, the file `weapon_shieldgun.txt` exists in the game resources with HUD icon data that was never utilized.

## Approach
Extend `GiveShield` to send a `WeaponList` placeholder entry for the shield and trigger the `WeapPickup` message when the player receives it. This activates the existing HUD assets so the shield displays its history icon consistently, matching the behavior of other items.

## Learning
https://github.com/Velaron/cs16-client/blob/87518233ad5f35a9c0f6ea8919ba98c4145834b6/cl_dll/ammo.cpp#L631
https://github.com/Velaron/cs16-client/blob/main/cl_dll/ammohistory.h
https://github.com/Velaron/cs16-client/blob/87518233ad5f35a9c0f6ea8919ba98c4145834b6/cl_dll/ammo.cpp#L530

[](https://www.youtube.com/watch?v=i2GEziOBA_o)