### PR TITLE
Fix CHalfLifeMultiplay::m_iMapVotes array access

### DIFF
--- a/regamedll/dlls/client.cpp
+++ b/regamedll/dlls/client.cpp
@@ -2786,9 +2786,9 @@ void EXT_FUNC InternalCommand(edict_t *pEntity, const char *pcmd, const char *pa
 
 				if (pPlayer->m_iMapVote)
 				{
-					if (--CSGameRules()->m_iMapVotes[pPlayer->m_iMapVote] < 0)
+					if (--CSGameRules()->m_iMapVotes[pPlayer->m_iMapVote - 1] < 0)
 					{
-						CSGameRules()->m_iMapVotes[pPlayer->m_iMapVote] = 0;
+						CSGameRules()->m_iMapVotes[pPlayer->m_iMapVote - 1] = 0;
 					}
 				}
 

--- a/regamedll/dlls/multiplay_gamerules.cpp
+++ b/regamedll/dlls/multiplay_gamerules.cpp
@@ -3611,11 +3611,11 @@ void CHalfLifeMultiplay::ClientDisconnected(edict_t *pClient)
 
 			if (pPlayer->m_iMapVote)
 			{
-				m_iMapVotes[pPlayer->m_iMapVote]--;
+				m_iMapVotes[pPlayer->m_iMapVote - 1]--;
 
-				if (m_iMapVotes[pPlayer->m_iMapVote] < 0)
+				if (m_iMapVotes[pPlayer->m_iMapVote - 1] < 0)
 				{
-					m_iMapVotes[pPlayer->m_iMapVote] = 0;
+					m_iMapVotes[pPlayer->m_iMapVote - 1] = 0;
 				}
 			}
 
@@ -4815,13 +4815,13 @@ void CHalfLifeMultiplay::DisplayMaps(CBasePlayer *pPlayer, int iVote)
 
 		if (pPlayer)
 		{
-			if (m_iMapVotes[iCount] == 1)
+			if (m_iMapVotes[iCount - 1] == 1)
 			{
 				ClientPrint(pPlayer->pev, HUD_PRINTCONSOLE, "#Vote", UTIL_dtos1(iCount), item->mapname, UTIL_dtos2(1));
 			}
 			else
 			{
-				ClientPrint(pPlayer->pev, HUD_PRINTCONSOLE, "#Votes", UTIL_dtos1(iCount), item->mapname, UTIL_dtos2(m_iMapVotes[iCount]));
+				ClientPrint(pPlayer->pev, HUD_PRINTCONSOLE, "#Votes", UTIL_dtos1(iCount), item->mapname, UTIL_dtos2(m_iMapVotes[iCount - 1]));
 			}
 		}
 
@@ -4877,7 +4877,7 @@ void CHalfLifeMultiplay::ProcessMapVote(CBasePlayer *pPlayer, int iVote)
 		}
 	}
 
-	m_iMapVotes[iVote] = iValidVotes;
+	m_iMapVotes[iVote - 1] = iValidVotes;
 
 	float ratio = mapvoteratio.value;
 	if (mapvoteratio.value > 1)


### PR DESCRIPTION
`votemap` command uses indexes in range `[1, MAX_VOTE_MAPS]` while the array index is 0-based.
This fix avoid array index overflow when vote id is MAX_VOTE_MAPS.
I checked the original binary and confirm this should be the same behavior with the original code.