### PR TITLE
Allow reload on weapons with altered ammo type

### DIFF
--- a/regamedll/dlls/wpn_shared/wpn_ak47.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_ak47.cpp
@@ -175,7 +175,7 @@ void CAK47::Reload()
 {
 #ifdef REGAMEDLL_FIXES
 	// to prevent reload if not enough ammo
-	if (m_pPlayer->ammo_762nato <= 0)
+	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		return;
 #endif
 

--- a/regamedll/dlls/wpn_shared/wpn_ak47.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_ak47.cpp
@@ -173,12 +173,6 @@ void CAK47::AK47Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CAK47::Reload()
 {
-#ifdef REGAMEDLL_FIXES
-	// to prevent reload if not enough ammo
-	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
-		return;
-#endif
-
 	if (DefaultReload(iMaxClip(), AK47_RELOAD, AK47_RELOAD_TIME))
 	{
 		m_pPlayer->SetAnimation(PLAYER_RELOAD);

--- a/regamedll/dlls/wpn_shared/wpn_aug.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_aug.cpp
@@ -190,7 +190,7 @@ void CAUG::AUGFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CAUG::Reload()
 {
-	if (m_pPlayer->ammo_556nato <= 0)
+	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), AUG_RELOAD, AUG_RELOAD_TIME))

--- a/regamedll/dlls/wpn_shared/wpn_aug.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_aug.cpp
@@ -190,8 +190,10 @@ void CAUG::AUGFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CAUG::Reload()
 {
-	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+#ifndef REGAMEDLL_FIXES
+	if (m_pPlayer->ammo_556nato <= 0)
 		return;
+#endif
 
 	if (DefaultReload(iMaxClip(), AUG_RELOAD, AUG_RELOAD_TIME))
 	{

--- a/regamedll/dlls/wpn_shared/wpn_awp.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_awp.cpp
@@ -198,7 +198,7 @@ void CAWP::AWPFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CAWP::Reload()
 {
-	if (m_pPlayer->ammo_338mag <= 0)
+	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), AWP_RELOAD, AWP_RELOAD_TIME))

--- a/regamedll/dlls/wpn_shared/wpn_awp.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_awp.cpp
@@ -198,8 +198,10 @@ void CAWP::AWPFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CAWP::Reload()
 {
-	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+#ifndef REGAMEDLL_FIXES
+	if (m_pPlayer->ammo_338mag <= 0)
 		return;
+#endif
 
 	if (DefaultReload(iMaxClip(), AWP_RELOAD, AWP_RELOAD_TIME))
 	{

--- a/regamedll/dlls/wpn_shared/wpn_deagle.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_deagle.cpp
@@ -187,7 +187,7 @@ void CDEAGLE::DEAGLEFire(float flSpread, float flCycleTime, BOOL fUseSemi)
 
 void CDEAGLE::Reload()
 {
-	if (m_pPlayer->ammo_50ae <= 0)
+	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), DEAGLE_RELOAD, DEAGLE_RELOAD_TIME))

--- a/regamedll/dlls/wpn_shared/wpn_deagle.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_deagle.cpp
@@ -187,8 +187,10 @@ void CDEAGLE::DEAGLEFire(float flSpread, float flCycleTime, BOOL fUseSemi)
 
 void CDEAGLE::Reload()
 {
-	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+#ifndef REGAMEDLL_FIXES
+	if (m_pPlayer->ammo_50ae <= 0)
 		return;
+#endif
 
 	if (DefaultReload(iMaxClip(), DEAGLE_RELOAD, DEAGLE_RELOAD_TIME))
 	{

--- a/regamedll/dlls/wpn_shared/wpn_elite.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_elite.cpp
@@ -209,7 +209,7 @@ void CELITE::ELITEFire(float flSpread, float flCycleTime, BOOL fUseSemi)
 
 void CELITE::Reload()
 {
-	if (m_pPlayer->ammo_9mm <= 0)
+	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), ELITE_RELOAD, ELITE_RELOAD_TIME))

--- a/regamedll/dlls/wpn_shared/wpn_elite.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_elite.cpp
@@ -209,8 +209,10 @@ void CELITE::ELITEFire(float flSpread, float flCycleTime, BOOL fUseSemi)
 
 void CELITE::Reload()
 {
-	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+#ifndef REGAMEDLL_FIXES
+	if (m_pPlayer->ammo_9mm <= 0)
 		return;
+#endif
 
 	if (DefaultReload(iMaxClip(), ELITE_RELOAD, ELITE_RELOAD_TIME))
 	{

--- a/regamedll/dlls/wpn_shared/wpn_famas.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_famas.cpp
@@ -216,8 +216,10 @@ void CFamas::FamasFire(float flSpread, float flCycleTime, BOOL fUseAutoAim, BOOL
 
 void CFamas::Reload()
 {
-	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+#ifndef REGAMEDLL_FXES
+	if (m_pPlayer->ammo_556nato <= 0)
 		return;
+#endif
 
 	if (DefaultReload(iMaxClip(), FAMAS_RELOAD, FAMAS_RELOAD_TIME))
 	{

--- a/regamedll/dlls/wpn_shared/wpn_famas.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_famas.cpp
@@ -216,7 +216,7 @@ void CFamas::FamasFire(float flSpread, float flCycleTime, BOOL fUseAutoAim, BOOL
 
 void CFamas::Reload()
 {
-	if (m_pPlayer->ammo_556nato <= 0)
+	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), FAMAS_RELOAD, FAMAS_RELOAD_TIME))

--- a/regamedll/dlls/wpn_shared/wpn_fiveseven.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_fiveseven.cpp
@@ -186,8 +186,10 @@ void CFiveSeven::FiveSevenFire(float flSpread, float flCycleTime, BOOL fUseSemi)
 
 void CFiveSeven::Reload()
 {
-	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+#ifndef REGAMEDLL_FIXES
+	if (m_pPlayer->ammo_57mm <= 0)
 		return;
+#endif
 
 	if (DefaultReload(iMaxClip(), FIVESEVEN_RELOAD, FIVESEVEN_RELOAD_TIME))
 	{

--- a/regamedll/dlls/wpn_shared/wpn_fiveseven.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_fiveseven.cpp
@@ -186,7 +186,7 @@ void CFiveSeven::FiveSevenFire(float flSpread, float flCycleTime, BOOL fUseSemi)
 
 void CFiveSeven::Reload()
 {
-	if (m_pPlayer->ammo_57mm <= 0)
+	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), FIVESEVEN_RELOAD, FIVESEVEN_RELOAD_TIME))

--- a/regamedll/dlls/wpn_shared/wpn_g3sg1.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_g3sg1.cpp
@@ -198,8 +198,10 @@ void CG3SG1::G3SG1Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CG3SG1::Reload()
 {
-	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+#ifndef REGAMEDLL_FIXES
+	if (m_pPlayer->ammo_762nato <= 0)
 		return;
+#endif
 
 	if (DefaultReload(iMaxClip(), G3SG1_RELOAD, G3SG1_RELOAD_TIME))
 	{

--- a/regamedll/dlls/wpn_shared/wpn_g3sg1.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_g3sg1.cpp
@@ -198,7 +198,7 @@ void CG3SG1::G3SG1Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CG3SG1::Reload()
 {
-	if (m_pPlayer->ammo_762nato <= 0)
+	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), G3SG1_RELOAD, G3SG1_RELOAD_TIME))

--- a/regamedll/dlls/wpn_shared/wpn_galil.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_galil.cpp
@@ -176,12 +176,6 @@ void CGalil::GalilFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CGalil::Reload()
 {
-#ifdef REGAMEDLL_FIXES
-	// to prevent reload if not enough ammo
-	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
-		return;
-#endif
-
 	if (DefaultReload(iMaxClip(), GALIL_RELOAD, GALIL_RELOAD_TIME))
 	{
 		m_pPlayer->SetAnimation(PLAYER_RELOAD);

--- a/regamedll/dlls/wpn_shared/wpn_galil.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_galil.cpp
@@ -178,7 +178,7 @@ void CGalil::Reload()
 {
 #ifdef REGAMEDLL_FIXES
 	// to prevent reload if not enough ammo
-	if (m_pPlayer->ammo_556nato <= 0)
+	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		return;
 #endif
 

--- a/regamedll/dlls/wpn_shared/wpn_glock18.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_glock18.cpp
@@ -262,7 +262,7 @@ void CGLOCK18::GLOCK18Fire(float flSpread, float flCycleTime, BOOL bFireBurst)
 void CGLOCK18::Reload()
 {
 	int iResult;
-	if (m_pPlayer->ammo_9mm <= 0)
+	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		return;
 
 	if (m_pPlayer->HasShield())

--- a/regamedll/dlls/wpn_shared/wpn_glock18.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_glock18.cpp
@@ -262,8 +262,10 @@ void CGLOCK18::GLOCK18Fire(float flSpread, float flCycleTime, BOOL bFireBurst)
 void CGLOCK18::Reload()
 {
 	int iResult;
-	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+#ifndef REGAMEDLL_FIXES
+	if (m_pPlayer->ammo_9mm <= 0)
 		return;
+#endif
 
 	if (m_pPlayer->HasShield())
 		iResult = GLOCK18_SHIELD_RELOAD;

--- a/regamedll/dlls/wpn_shared/wpn_m249.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_m249.cpp
@@ -172,7 +172,7 @@ void CM249::Reload()
 {
 #ifdef REGAMEDLL_FIXES
 	// to prevent reload if not enough ammo
-	if (m_pPlayer->ammo_556natobox <= 0)
+	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		return;
 #endif
 

--- a/regamedll/dlls/wpn_shared/wpn_m249.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_m249.cpp
@@ -170,12 +170,6 @@ void CM249::M249Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CM249::Reload()
 {
-#ifdef REGAMEDLL_FIXES
-	// to prevent reload if not enough ammo
-	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
-		return;
-#endif
-
 	if (DefaultReload(iMaxClip(), M249_RELOAD, M249_RELOAD_TIME))
 	{
 		m_pPlayer->SetAnimation(PLAYER_RELOAD);

--- a/regamedll/dlls/wpn_shared/wpn_m4a1.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_m4a1.cpp
@@ -229,8 +229,10 @@ void CM4A1::M4A1Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CM4A1::Reload()
 {
-	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+#ifndef REGAMEDLL_FIXES
+	if (m_pPlayer->ammo_556nato <= 0)
 		return;
+#endif
 
 	if (DefaultReload(iMaxClip(), ((m_iWeaponState & WPNSTATE_M4A1_SILENCED) == WPNSTATE_M4A1_SILENCED) ? M4A1_RELOAD : M4A1_UNSIL_RELOAD, M4A1_RELOAD_TIME))
 	{

--- a/regamedll/dlls/wpn_shared/wpn_m4a1.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_m4a1.cpp
@@ -229,7 +229,7 @@ void CM4A1::M4A1Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CM4A1::Reload()
 {
-	if (m_pPlayer->ammo_556nato <= 0)
+	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), ((m_iWeaponState & WPNSTATE_M4A1_SILENCED) == WPNSTATE_M4A1_SILENCED) ? M4A1_RELOAD : M4A1_UNSIL_RELOAD, M4A1_RELOAD_TIME))

--- a/regamedll/dlls/wpn_shared/wpn_mac10.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_mac10.cpp
@@ -163,7 +163,7 @@ void CMAC10::MAC10Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CMAC10::Reload()
 {
-	if (m_pPlayer->ammo_45acp <= 0)
+	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), MAC10_RELOAD, MAC10_RELOAD_TIME))

--- a/regamedll/dlls/wpn_shared/wpn_mac10.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_mac10.cpp
@@ -163,8 +163,10 @@ void CMAC10::MAC10Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CMAC10::Reload()
 {
-	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+#ifndef REGAMEDLL_FIXES
+	if (m_pPlayer->ammo_45acp <= 0)
 		return;
+#endif
 
 	if (DefaultReload(iMaxClip(), MAC10_RELOAD, MAC10_RELOAD_TIME))
 	{

--- a/regamedll/dlls/wpn_shared/wpn_mp5navy.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_mp5navy.cpp
@@ -164,8 +164,10 @@ void CMP5N::MP5NFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CMP5N::Reload()
 {
-	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+#ifndef REGAMEDLL_FIXES
+	if (m_pPlayer->ammo_9mm <= 0)
 		return;
+#endif
 
 	if (DefaultReload(iMaxClip(), MP5N_RELOAD, MP5N_RELOAD_TIME))
 	{

--- a/regamedll/dlls/wpn_shared/wpn_mp5navy.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_mp5navy.cpp
@@ -164,7 +164,7 @@ void CMP5N::MP5NFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CMP5N::Reload()
 {
-	if (m_pPlayer->ammo_9mm <= 0)
+	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), MP5N_RELOAD, MP5N_RELOAD_TIME))

--- a/regamedll/dlls/wpn_shared/wpn_p228.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_p228.cpp
@@ -186,7 +186,7 @@ void CP228::P228Fire(float flSpread, float flCycleTime, BOOL fUseSemi)
 
 void CP228::Reload()
 {
-	if (m_pPlayer->ammo_357sig <= 0)
+	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), m_pPlayer->HasShield() ? P228_SHIELD_RELOAD : P228_RELOAD, P228_RELOAD_TIME))

--- a/regamedll/dlls/wpn_shared/wpn_p228.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_p228.cpp
@@ -186,8 +186,10 @@ void CP228::P228Fire(float flSpread, float flCycleTime, BOOL fUseSemi)
 
 void CP228::Reload()
 {
-	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+#ifndef REGAMEDLL_FIXES
+	if (m_pPlayer->ammo_357sig <= 0)
 		return;
+#endif
 
 	if (DefaultReload(iMaxClip(), m_pPlayer->HasShield() ? P228_SHIELD_RELOAD : P228_RELOAD, P228_RELOAD_TIME))
 	{

--- a/regamedll/dlls/wpn_shared/wpn_p90.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_p90.cpp
@@ -170,7 +170,7 @@ void CP90::P90Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CP90::Reload()
 {
-	if (m_pPlayer->ammo_57mm <= 0)
+	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), P90_RELOAD, P90_RELOAD_TIME))

--- a/regamedll/dlls/wpn_shared/wpn_p90.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_p90.cpp
@@ -170,8 +170,10 @@ void CP90::P90Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CP90::Reload()
 {
-	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+#ifndef REGAMEDLL_FIXES
+	if (m_pPlayer->ammo_57mm <= 0)
 		return;
+#endif
 
 	if (DefaultReload(iMaxClip(), P90_RELOAD, P90_RELOAD_TIME))
 	{

--- a/regamedll/dlls/wpn_shared/wpn_scout.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_scout.cpp
@@ -190,12 +190,6 @@ void CSCOUT::SCOUTFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CSCOUT::Reload()
 {
-#ifdef REGAMEDLL_FIXES
-	// to prevent reload if not enough ammo
-	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
-		return;
-#endif
-
 	if (DefaultReload(iMaxClip(), SCOUT_RELOAD, SCOUT_RELOAD_TIME))
 	{
 		if (m_pPlayer->pev->fov != DEFAULT_FOV)

--- a/regamedll/dlls/wpn_shared/wpn_scout.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_scout.cpp
@@ -192,7 +192,7 @@ void CSCOUT::Reload()
 {
 #ifdef REGAMEDLL_FIXES
 	// to prevent reload if not enough ammo
-	if (m_pPlayer->ammo_762nato <= 0)
+	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		return;
 #endif
 

--- a/regamedll/dlls/wpn_shared/wpn_sg550.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_sg550.cpp
@@ -201,7 +201,7 @@ void CSG550::SG550Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CSG550::Reload()
 {
-	if (m_pPlayer->ammo_556nato <= 0)
+	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), SG550_RELOAD, SG550_RELOAD_TIME))

--- a/regamedll/dlls/wpn_shared/wpn_sg550.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_sg550.cpp
@@ -201,8 +201,10 @@ void CSG550::SG550Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CSG550::Reload()
 {
-	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+#ifndef REGAMEDLL_FIXES
+	if (m_pPlayer->ammo_556nato <= 0)
 		return;
+#endif
 
 	if (DefaultReload(iMaxClip(), SG550_RELOAD, SG550_RELOAD_TIME))
 	{

--- a/regamedll/dlls/wpn_shared/wpn_sg552.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_sg552.cpp
@@ -189,8 +189,10 @@ void CSG552::SG552Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CSG552::Reload()
 {
-	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+#ifndef REGAMEDLL_FIXES
+	if (m_pPlayer->ammo_556nato <= 0)
 		return;
+#endif
 
 	if (DefaultReload(iMaxClip(), SG552_RELOAD, SG552_RELOAD_TIME))
 	{

--- a/regamedll/dlls/wpn_shared/wpn_sg552.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_sg552.cpp
@@ -189,7 +189,7 @@ void CSG552::SG552Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CSG552::Reload()
 {
-	if (m_pPlayer->ammo_556nato <= 0)
+	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), SG552_RELOAD, SG552_RELOAD_TIME))

--- a/regamedll/dlls/wpn_shared/wpn_tmp.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_tmp.cpp
@@ -161,12 +161,6 @@ void CTMP::TMPFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CTMP::Reload()
 {
-#ifdef REGAMEDLL_FIXES
-	// to prevent reload if not enough ammo
-	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
-		return;
-#endif
-
 	if (DefaultReload(iMaxClip(), TMP_RELOAD, TMP_RELOAD_TIME))
 	{
 		m_pPlayer->SetAnimation(PLAYER_RELOAD);

--- a/regamedll/dlls/wpn_shared/wpn_tmp.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_tmp.cpp
@@ -163,7 +163,7 @@ void CTMP::Reload()
 {
 #ifdef REGAMEDLL_FIXES
 	// to prevent reload if not enough ammo
-	if (m_pPlayer->ammo_9mm <= 0)
+	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		return;
 #endif
 

--- a/regamedll/dlls/wpn_shared/wpn_ump45.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_ump45.cpp
@@ -167,7 +167,7 @@ void CUMP45::UMP45Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CUMP45::Reload()
 {
-	if (m_pPlayer->ammo_45acp <= 0)
+	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), UMP45_RELOAD, UMP45_RELOAD_TIME))

--- a/regamedll/dlls/wpn_shared/wpn_ump45.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_ump45.cpp
@@ -167,8 +167,10 @@ void CUMP45::UMP45Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CUMP45::Reload()
 {
-	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+#ifndef REGAMEDLL_FIXES
+	if (m_pPlayer->ammo_45acp <= 0)
 		return;
+#endif
 
 	if (DefaultReload(iMaxClip(), UMP45_RELOAD, UMP45_RELOAD_TIME))
 	{

--- a/regamedll/dlls/wpn_shared/wpn_usp.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_usp.cpp
@@ -249,7 +249,7 @@ void CUSP::USPFire(float flSpread, float flCycleTime, BOOL fUseSemi)
 
 void CUSP::Reload()
 {
-	if (m_pPlayer->ammo_45acp <= 0)
+	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		return;
 
 	int iAnim;

--- a/regamedll/dlls/wpn_shared/wpn_usp.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_usp.cpp
@@ -249,8 +249,10 @@ void CUSP::USPFire(float flSpread, float flCycleTime, BOOL fUseSemi)
 
 void CUSP::Reload()
 {
-	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+#ifndef REGAMEDLL_FIXES
+	if (m_pPlayer->ammo_45acp <= 0)
 		return;
+#endif
 
 	int iAnim;
 	if (m_pPlayer->HasShield())


### PR DESCRIPTION
## Purpose
ReGameDLL already gives support via ReAPI to implement custom ammo types, making possible to change the ammo type of any weapon, the current checks of weapon reload is that the player needs to have the original ammo type of the weapon in order to reload, which lead into issues if the user wishes to alter the current ammo type.

## Approach
It now checks with the current item's ammo type instead of a hardcoded ammo type.

If there's a particular reason why to check the reload function with a hardcoded ammo type instead of grabbing the current item's ammo type, please explain.
