### PR TITLE
Add `mp_knife_wall_sparks` cvar: spark effect when a knife hits a wall

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ This means that plugins that do binary code analysis (Orpheu for example) probab
 | mp_playerid_showhealth             | 1       | 0   | 2            | Player ID display mode.<br/>`0` don't show health<br/>`1` show health for teammates only (default CS behaviour)<br/>`2` show health for all players |
 | mp_playerid_field                  | 3       | 0   | 3            | Player ID field display mode.<br/>`0` don't show additional information<br/>`1` show team name<br/>`2` show health percentage<br/>`3` show both team name and health percentage |
 | mp_knockback                       | 170     | -   | -            | Knockback force applied to the victim when damaged by strong weapons (e.g. `AWP`, `AK47`).<br/>Works only if not crouching, and not hit in the legs.<br/>Set to `0` to disable. |
+| mp_knife_wall_sparks               | 0       | 0   | 1            | Show a spark effect at the point of impact when a knife hits a wall.<br/>`0` disabled<br/>`1` enabled |
 
 </details>
 

--- a/dist/game.cfg
+++ b/dist/game.cfg
@@ -698,3 +698,10 @@ mp_playerid_field "3"
 //
 // Default: "170"
 mp_knockback "170"
+
+// Show a spark effect at the point of impact when a knife hits a wall
+// 0 - disabled (default behavior)
+// 1 - enabled
+//
+// Default value: "0"
+mp_knife_wall_sparks "0"

--- a/regamedll/dlls/game.cpp
+++ b/regamedll/dlls/game.cpp
@@ -201,6 +201,8 @@ cvar_t playerid_field          = { "mp_playerid_field", "3", 0, 3.0f, nullptr };
 
 cvar_t knockback               = { "mp_knockback", "170", 0, 170.0f, nullptr };
 
+cvar_t knife_wall_sparks       = { "mp_knife_wall_sparks", "0", 0, 0.0f, nullptr };
+
 void GameDLL_Version_f()
 {
 	if (Q_stricmp(CMD_ARGV(1), "version") != 0)
@@ -488,6 +490,8 @@ void EXT_FUNC GameDLLInit()
 	CVAR_REGISTER(&flymove_method);
 
 	CVAR_REGISTER(&knockback);
+
+	CVAR_REGISTER(&knife_wall_sparks);
 
 	// print version
 	CONSOLE_ECHO("ReGameDLL version: " APP_VERSION "\n");

--- a/regamedll/dlls/game.h
+++ b/regamedll/dlls/game.h
@@ -217,6 +217,7 @@ extern cvar_t randomspawn;
 extern cvar_t playerid_showhealth;
 extern cvar_t playerid_field;
 extern cvar_t knockback;
+extern cvar_t knife_wall_sparks;
 
 #endif
 

--- a/regamedll/dlls/wpn_shared/wpn_knife.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_knife.cpp
@@ -456,6 +456,12 @@ BOOL CKnife::Swing(BOOL fFirst)
 		{
 			// also play knife strike
 			EMIT_SOUND_DYN(m_pPlayer->edict(), CHAN_ITEM, "weapons/knife_hitwall1.wav", VOL_NORM, ATTN_NORM, 0, RANDOM_LONG(0, 3) + 98);
+
+#ifdef REGAMEDLL_ADD
+			// spark effect at the point of impact
+			if (knife_wall_sparks.value)
+				UTIL_Sparks(tr.vecEndPos);
+#endif
 		}
 	}
 
@@ -633,6 +639,12 @@ BOOL CKnife::Stab(BOOL fFirst)
 		{
 			// also play knife strike
 			EMIT_SOUND_DYN(m_pPlayer->edict(), CHAN_ITEM, "weapons/knife_hitwall1.wav", VOL_NORM, ATTN_NORM, 0, RANDOM_LONG(0, 3) + 98);
+
+#ifdef REGAMEDLL_ADD
+			// spark effect at the point of impact
+			if (knife_wall_sparks.value)
+				UTIL_Sparks(tr.vecEndPos);
+#endif
 		}
 	}
 


### PR DESCRIPTION
## What

New cvar `mp_knife_wall_sparks` (default `0` — original behavior). When enabled, a spark effect (`TE_SPARKS`) is shown at the point of impact whenever a knife hits a wall — both for the slash (`CKnife::Swing`) and the stab (`CKnife::Stab`) attack, in the exact code branches where `weapons/knife_hitwall1.wav` is played.

## Why

This is a popular cosmetic tweak that servers currently implement with AMXX plugins that hook every `EmitSound` call and reconstruct the impact point indirectly (via `get_user_aiming` and distance heuristics), which is both inaccurate and wasteful. Native support is a one-liner per attack path using the existing `UTIL_Sparks()` utility:

- the exact impact point is taken from the attack `TraceResult`;
- the effect is sent as `MSG_PVS` (only to nearby players), not `MSG_ALL`;
- zero overhead when the cvar is disabled.

## Implementation notes

- Gated by `#ifdef REGAMEDLL_ADD`, vanilla builds are unaffected.
- Default `0` keeps the original behavior bit-for-bit.
- Documented in `README.md` and `dist/game.cfg`.

## Tested

Verified on a live ReHLDS server (Windows, CS 1.6): with `mp_knife_wall_sparks 1` sparks appear at the exact impact point for both attack buttons; with `0` behavior is identical to the original (sound only). The cvar can be toggled at runtime.
