### PR TITLE
Add `mp_show_bomb_timer` cvar: show C4 countdown on the HUD round timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ This means that plugins that do binary code analysis (Orpheu for example) probab
 | mp_hostage_hurtable                | 1       | 0   | 1            | The hostages can take damage.<br/>`0` disabled<br/>`1` from any team<br/>`2` only from `CT`<br/>`3` only from `T` |
 | mp_show_radioicon                  | 1       | 0   | 1            | Show radio icon.<br/>`0` disabled<br/>`1` enabled |
 | mp_show_scenarioicon               | 0       | 0   | 1            | Show scenario icon in HUD such as count of alive hostages or ticking bomb.<br/>`0` disabled<br/>`1` enabled |
+| mp_show_bomb_timer                 | 0       | 0   | 1            | Show the time until the planted bomb explodes on the HUD round timer.<br/>`0` disabled<br/>`1` enabled (when the bomb is planted, the round timer shows the C4 countdown) |
 | mp_old_bomb_defused_sound          | 1       | 0   | 1            | Play "Bomb has been defused" sound instead of "Counter-Terrorists win" when bomb was defused<br/>`0` disabled<br/>`1` enabled |
 | showtriggers                       | 0       | 0   | 1            | Debug cvar shows triggers. |
 | sv_alltalk                         | 0       | 0   | 5            | When players can hear each other ([further explanation](../../wiki/sv_alltalk)).<br/>`0` dead don't hear alive<br/>`1` no restrictions<br/>`2` teammates hear each other<br/>`3` Same as 2, but spectators hear everybody<br/>`4` alive hear alive, dead hear dead and alive.<br/>`5` alive hear alive teammates, dead hear dead and alive.

--- a/dist/game.cfg
+++ b/dist/game.cfg
@@ -191,6 +191,13 @@ mp_show_radioicon "1"
 // Default value: "0"
 mp_show_scenarioicon "0"
 
+// Show the time until the planted bomb explodes on the HUD round timer
+// 0 - disabled (default behavior)
+// 1 - enabled (when the bomb is planted, the round timer shows the C4 countdown)
+//
+// Default value: "0"
+mp_show_bomb_timer "0"
+
 // Play "Bomb has been defused" sound instead of "Counter-Terrorists win" when bomb was defused
 // 0 - disabled (default behavior)
 // 1 - enabled

--- a/regamedll/dlls/game.cpp
+++ b/regamedll/dlls/game.cpp
@@ -201,6 +201,8 @@ cvar_t playerid_field          = { "mp_playerid_field", "3", 0, 3.0f, nullptr };
 
 cvar_t knockback               = { "mp_knockback", "170", 0, 170.0f, nullptr };
 
+cvar_t show_bomb_timer         = { "mp_show_bomb_timer", "0", 0, 0.0f, nullptr };
+
 void GameDLL_Version_f()
 {
 	if (Q_stricmp(CMD_ARGV(1), "version") != 0)
@@ -488,6 +490,8 @@ void EXT_FUNC GameDLLInit()
 	CVAR_REGISTER(&flymove_method);
 
 	CVAR_REGISTER(&knockback);
+
+	CVAR_REGISTER(&show_bomb_timer);
 
 	// print version
 	CONSOLE_ECHO("ReGameDLL version: " APP_VERSION "\n");

--- a/regamedll/dlls/game.h
+++ b/regamedll/dlls/game.h
@@ -217,6 +217,7 @@ extern cvar_t randomspawn;
 extern cvar_t playerid_showhealth;
 extern cvar_t playerid_field;
 extern cvar_t knockback;
+extern cvar_t show_bomb_timer;
 
 #endif
 

--- a/regamedll/dlls/ggrenade.cpp
+++ b/regamedll/dlls/ggrenade.cpp
@@ -1155,6 +1155,12 @@ void CGrenade::__API_HOOK(DefuseBombEnd)(CBasePlayer *pPlayer, bool bDefused)
 			g_pGameRules->m_bBombDropped = FALSE;
 			m_pBombDefuser = nullptr;
 			m_bStartDefuse = false;
+
+#ifdef REGAMEDLL_ADD
+			// restore the HUD round timer
+			if (show_bomb_timer.value != 0.0f)
+				SyncRoundTimerForAll();
+#endif
 		}
 		else
 		{

--- a/regamedll/dlls/ggrenade.cpp
+++ b/regamedll/dlls/ggrenade.cpp
@@ -119,6 +119,13 @@ void CGrenade::__API_HOOK(Explode2)(TraceResult *pTrace, int bitsDamageType)
 	m_bJustBlew = true;
 	CSGameRules()->CheckWinConditions();
 
+#ifdef REGAMEDLL_ADD
+	// restore the HUD round timer if the round did not end on the explosion
+	// (e.g. mp_round_infinite blocks the bomb round-end check)
+	if (show_bomb_timer.value != 0.0f)
+		SyncRoundTimerForAll();
+#endif
+
 	// Pull out of the wall a bit
 	if (pTrace->flFraction != 1.0f)
 	{

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -3603,14 +3603,59 @@ void CBasePlayer::ResetMenu()
 	MESSAGE_END();
 }
 
+#ifdef REGAMEDLL_ADD
+// Find the planted C4 in the world, if any
+static CGrenade *FindPlantedBomb()
+{
+	CGrenade *pBomb = nullptr;
+	while ((pBomb = UTIL_FindEntityByClassname(pBomb, "grenade")))
+	{
+		// skip the ones marked for removal (just defused)
+		if (pBomb->m_bIsC4 && !(pBomb->pev->flags & FL_KILLME))
+			return pBomb;
+	}
+
+	return nullptr;
+}
+
+// Resync the HUD round timer for all players
+// (used when the timer switches between the round time and the C4 countdown)
+void SyncRoundTimerForAll()
+{
+	for (int i = 1; i <= gpGlobals->maxClients; i++)
+	{
+		CBasePlayer *pPlayer = UTIL_PlayerByIndex(i);
+		if (UTIL_IsValidPlayer(pPlayer))
+			pPlayer->SyncRoundTimer();
+	}
+}
+#endif
+
 void CBasePlayer::SyncRoundTimer()
 {
 	float tmRemaining = 0;
 	BOOL bFreezePeriod = g_pGameRules->IsFreezePeriod();
 
+#ifdef REGAMEDLL_ADD
+	bool bBombTimer = false;
+#endif
+
 	if (g_pGameRules->IsMultiplayer())
 	{
 		tmRemaining = CSGameRules()->GetRoundRemainingTimeReal();
+
+#ifdef REGAMEDLL_ADD
+		// show the time until the planted bomb explodes instead of the round timer
+		if (show_bomb_timer.value != 0.0f && !bFreezePeriod)
+		{
+			CGrenade *pBomb = FindPlantedBomb();
+			if (pBomb && pBomb->m_flC4Blow > gpGlobals->time)
+			{
+				tmRemaining = pBomb->m_flC4Blow - gpGlobals->time;
+				bBombTimer = true;
+			}
+		}
+#endif
 
 #ifdef REGAMEDLL_FIXES
 		// hide timer HUD because it is useless.
@@ -3630,6 +3675,15 @@ void CBasePlayer::SyncRoundTimer()
 
 	if (tmRemaining < 0)
 		tmRemaining = 0;
+
+#ifdef REGAMEDLL_ADD
+	// the client hides the HUD timer once the bomb is planted, re-show it
+	if (bBombTimer)
+	{
+		MESSAGE_BEGIN(MSG_ONE, gmsgShowTimer, nullptr, pev);
+		MESSAGE_END();
+	}
+#endif
 
 	MESSAGE_BEGIN(MSG_ONE, gmsgRoundTime, nullptr, pev);
 		WRITE_SHORT(int(tmRemaining));

--- a/regamedll/dlls/player.h
+++ b/regamedll/dlls/player.h
@@ -1060,3 +1060,7 @@ bool IsSecondaryWeaponClass(int classId);
 bool IsSecondaryWeaponId(int id);
 const char *GetWeaponAliasFromName(const char *weaponName);
 bool CurrentWeaponSatisfies(CBasePlayerWeapon *pWeapon, int id, int classId);
+
+#ifdef REGAMEDLL_ADD
+void SyncRoundTimerForAll();
+#endif

--- a/regamedll/dlls/wpn_shared/wpn_c4.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_c4.cpp
@@ -197,6 +197,13 @@ void CC4::PrimaryAttack()
 					WRITE_BYTE(BOMB_FLAG_PLANTED);
 				MESSAGE_END();
 
+#ifdef REGAMEDLL_ADD
+				// show the C4 countdown on the HUD round timer;
+				// must be sent after gmsgBombDrop, the client hides the timer on it
+				if (show_bomb_timer.value != 0.0f)
+					SyncRoundTimerForAll();
+#endif
+
 				UTIL_ClientPrintAll(HUD_PRINTCENTER, "#Bomb_Planted");
 				if (TheBots)
 				{


### PR DESCRIPTION
## What

New cvar `mp_show_bomb_timer` (default `0` - original behavior). When enabled, after the C4 is planted the HUD round timer shows the countdown to the explosion (driven by `m_flC4Blow`, the same value the game uses to detonate) instead of disappearing. After a successful defuse the timer switches back to the round time.

## How it works

The stock CS 1.6 client hides the HUD round timer when it receives `BombDrop` with the "planted" flag. Two things make the countdown display possible:

- `CBasePlayer::SyncRoundTimer()` now substitutes the remaining C4 time and precedes the `RoundTime` message with an empty `ShowTimer` message, which un-hides the timer on the client. Since `SyncRoundTimer` is the single place that drives the HUD timer, every existing sync point picks the feature up automatically: initial HUD sync on connect (`UpdateClientData`), respawn (`Spawn`), freeze end (`OnRoundFreezeEnd`).
- On plant, all players are resynced right **after** `gmsgBombDrop` is broadcast (`wpn_c4.cpp`), so within one frame the client processes: hide (BombDrop) ? show (ShowTimer) ? countdown value (RoundTime). No periodic resending is needed - the client counts down locally from the exact value.

Unlike the popular AMXX implementations (which hook the plant and re-send `ShowTimer` + `RoundTime` to all players every second forever), this is fully event-driven: two messages per player at plant/defuse and nothing in between.

## Edge cases covered

- **Same-frame defuse**: the just-defused C4 is marked `FL_KILLME` by `UTIL_Remove` before the resync, so the bomb lookup can never pick it up.
- **Aborted defuse** (released `+use` / defuser died): no resync, the countdown correctly keeps running.
- **Late join / reconnect / respawn while the bomb is ticking**: the initial HUD sync sends `ShowTimer` + the exact remaining time.
- **Round restart**: `CleanUpMap()` removes the C4 before any sync, plus the freeze-period guard - no stale bomb can leak into the new round.
- **`mp_roundtime 0` servers** (timer normally hidden as useless): the existing `HIDEHUD_TIMER` logic shows the timer for the countdown and hides it back after the defuse.
- **Explosion**: the client display reaches 0:00 exactly at the detonation, since both are driven by `m_flC4Blow`.
- The displayed value uses the same floor semantics as the stock round timer (the digit means "full seconds remaining").

## Behavior notes

- After a successful defuse the round timer is **restored**, not hidden. This is deliberate: with `mp_round_infinite` (flag `e`) or plugins that supersede the round end, the round continues after a defuse and the round time is meaningful again. On regular servers the round ends a few seconds later anyway and the next round resyncs everything - same visuals as any other round ending.
- If a plugin changes `m_flC4Blow` after the plant (ReAPI), the client countdown will not follow automatically - the plugin can trigger a resync itself; a periodic resync was intentionally avoided to keep the feature zero-cost.

## Tested

Verified on a live ReHLDS server (Windows, CS 1.6): plant (as T and observing as CT), successful defuse, aborted defuse, explosion, reconnect mid-countdown, `mp_show_bomb_timer 0` - behavior identical to the original.


---

**Edit:** restore the HUD round timer after the bomb explodes. If the bomb round-end check is blocked (`mp_round_infinite` flag `e`), the explosion does not end the round and the timer stayed frozen at 0:00; it is now resynced for all players in `CGrenade::Explode2`, mirroring the resync already done on defuse.