### PR TITLE
Fix global buffer overflow in `SharedParse()`

### DIFF
--- a/regamedll/CMakeLists.txt
+++ b/regamedll/CMakeLists.txt
@@ -337,6 +337,7 @@ set(GAMEDLL_SRCS
 
 set(UNITTESTS_SRCS
 	"unittests/animation_tests.cpp"
+	"unittests/shared_util_tests.cpp"
 	"unittests/struct_offsets_tests.cpp"
 	"unittests/TestRunner.cpp"
 )

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -9851,13 +9851,17 @@ void CBasePlayer::PrioritizeAutoBuyString(char (&autobuyString)[MAX_AUTOBUY_LENG
 		int i = 0;
 
 		// get the next token from the priority string.
-		while (*priorityChar != '\0' && *priorityChar != ' ')
+		while (*priorityChar != '\0' && *priorityChar != ' ' && i < (int)sizeof(priorityToken) - 1)
 		{
 			priorityToken[i++] = *priorityChar;
 			priorityChar++;
 		}
 
 		priorityToken[i] = '\0';
+
+		// skip the rest of an oversized token that did not fit
+		while (*priorityChar != '\0' && *priorityChar != ' ')
+			priorityChar++;
 
 		// skip spaces
 		while (*priorityChar == ' ')

--- a/regamedll/game_shared/shared_util.cpp
+++ b/regamedll/game_shared/shared_util.cpp
@@ -162,14 +162,17 @@ skipwhite:
 				return data;
 			}
 
-			s_shared_token[len++] = c;
+			// prevent overflow of the fixed-size token buffer
+			if (len < (int)sizeof(s_shared_token) - 1)
+				s_shared_token[len++] = c;
 		}
 	}
 
 	// parse single characters
 	if (c == '{' || c == '}'|| c == ')'|| c == '(' || c == '\'' || c == ',')
 	{
-		s_shared_token[len++] = c;
+		if (len < (int)sizeof(s_shared_token) - 1)
+			s_shared_token[len++] = c;
 		s_shared_token[len] = '\0';
 		return data + 1;
 	}
@@ -177,9 +180,9 @@ skipwhite:
 	// parse a regular word
 	do
 	{
-		s_shared_token[len] = c;
+		if (len < (int)sizeof(s_shared_token) - 1)
+			s_shared_token[len++] = c;
 		data++;
-		len++;
 		c = *data;
 
 		if (c == '{' || c == '}'|| c == ')'|| c == '(' || c == '\'' || c == ',')

--- a/regamedll/msvc/ReGameDLL.vcxproj
+++ b/regamedll/msvc/ReGameDLL.vcxproj
@@ -579,6 +579,12 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release Play|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug Play|Win32'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\unittests\shared_util_tests.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release Play|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug Play|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\unittests\struct_offsets_tests.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>

--- a/regamedll/unittests/shared_util_tests.cpp
+++ b/regamedll/unittests/shared_util_tests.cpp
@@ -1,0 +1,47 @@
+#include "precompiled.h"
+#include "cppunitlite/TestHarness.h"
+
+// Regression test for the SharedParse() global-buffer overflow.
+// s_shared_token is char[1500]; SharedParse() must never emit a token that
+// does not fit, regardless of the size of a single unquoted/quoted token in
+// the input. On the unpatched code the oversized-token cases below smash the
+// global buffer (crash / memory corruption) before the CHECK is even reached.
+const int SHARED_TOKEN_SIZE = 1500; // must match char s_shared_token[1500]
+
+TEST(RegularWordOverflow, SharedParse, 10)
+{
+	// One unquoted "word" of 5000 non-space characters (no quotes/specials).
+	static char input[5001];
+	Q_memset(input, 'A', sizeof(input) - 1);
+	input[sizeof(input) - 1] = '\0';
+
+	SharedParse(input);
+	CHECK(Q_strlen(SharedGetToken()) < SHARED_TOKEN_SIZE);
+}
+
+TEST(QuotedStringOverflow, SharedParse, 10)
+{
+	// One quoted string of 5000 characters between the quotes.
+	static char input[5003];
+	input[0] = '\"';
+	Q_memset(input + 1, 'B', 5000);
+	input[5001] = '\"';
+	input[5002] = '\0';
+
+	SharedParse(input);
+	CHECK(Q_strlen(SharedGetToken()) < SHARED_TOKEN_SIZE);
+}
+
+TEST(NormalTokensStillWork, SharedParse, 10)
+{
+	// The fix must not change behavior for well-formed input.
+	char input[] = "  primaryWeapon   \"hello world\"  , ";
+	char *p = SharedParse(input);
+	CHECK(Q_strcmp(SharedGetToken(), "primaryWeapon") == 0);
+
+	p = SharedParse(p);
+	CHECK(Q_strcmp(SharedGetToken(), "hello world") == 0);
+
+	p = SharedParse(p);
+	CHECK(Q_strcmp(SharedGetToken(), ",") == 0);
+}

--- a/regamedll/unittests/shared_util_tests.cpp
+++ b/regamedll/unittests/shared_util_tests.cpp
@@ -16,7 +16,7 @@ TEST(RegularWordOverflow, SharedParse, 10)
 	input[sizeof(input) - 1] = '\0';
 
 	SharedParse(input);
-	CHECK(Q_strlen(SharedGetToken()) < SHARED_TOKEN_SIZE);
+	CHECK("oversized word must be truncated", Q_strlen(SharedGetToken()) < SHARED_TOKEN_SIZE);
 }
 
 TEST(QuotedStringOverflow, SharedParse, 10)
@@ -29,7 +29,7 @@ TEST(QuotedStringOverflow, SharedParse, 10)
 	input[5002] = '\0';
 
 	SharedParse(input);
-	CHECK(Q_strlen(SharedGetToken()) < SHARED_TOKEN_SIZE);
+	CHECK("oversized quoted string must be truncated", Q_strlen(SharedGetToken()) < SHARED_TOKEN_SIZE);
 }
 
 TEST(NormalTokensStillWork, SharedParse, 10)
@@ -37,11 +37,11 @@ TEST(NormalTokensStillWork, SharedParse, 10)
 	// The fix must not change behavior for well-formed input.
 	char input[] = "  primaryWeapon   \"hello world\"  , ";
 	char *p = SharedParse(input);
-	CHECK(Q_strcmp(SharedGetToken(), "primaryWeapon") == 0);
+	CHECK("plain word token", Q_strcmp(SharedGetToken(), "primaryWeapon") == 0);
 
 	p = SharedParse(p);
-	CHECK(Q_strcmp(SharedGetToken(), "hello world") == 0);
+	CHECK("quoted string token", Q_strcmp(SharedGetToken(), "hello world") == 0);
 
 	p = SharedParse(p);
-	CHECK(Q_strcmp(SharedGetToken(), ",") == 0);
+	CHECK("comma token", Q_strcmp(SharedGetToken(), ",") == 0);
 }


### PR DESCRIPTION
## What

`SharedParse()` copies each parsed token into the fixed-size global buffer `s_shared_token[1500]` without any bounds checking, so a single token longer than 1499 bytes overflows the buffer.

## Why (Root cause)

The three token-writing sites in `SharedParse()` - quoted string, single special character, and regular word - increment `len` and write `s_shared_token[len]` with no check against the buffer size:

```cpp
s_shared_token[len++] = c;   // quoted string / special char
...
s_shared_token[len] = c; len++;   // regular word
```

Any input that contains one token (quoted or unquoted) longer than the buffer overruns it and corrupts the globals that follow, which can crash the server or corrupt parser state.

The buffer is fed from data files parsed through `LOAD_FILE_FOR_ME` - `botprofile.db`, `BotChatter.db`, `mapcycle.txt`, tutor messages - and from the `ct/t_default_weapons_*` cvars, so a malformed or maliciously crafted file/config is enough to trigger it. The sibling parser `CBasePlayer::ParseAutoBuyString()` already bounds its copy correctly; `SharedParse()` simply misses the same guard.

## How it works

Bound each of the three writes to `sizeof(s_shared_token) - 1`, mirroring the existing check in `ParseAutoBuyString()`. Oversized tokens are safely truncated and still null-terminated, and parsing resumes from the correct position.

## Edge cases

- Well-formed input is byte-for-byte unchanged; only a token longer than the buffer is truncated.
- Truncation keeps the `'\0'` terminator and the returned parse position intact, so the surrounding parse loops behave as before.
- Applies equally to quoted strings, single special characters, and regular words.

## Tested

- New unit tests (`unittests/shared_util_tests.cpp`): oversized unquoted word, oversized quoted string, and a normal-token regression (`primaryWeapon` / `"hello world"` / `,`).
- Release build (MSVC v145) compiles cleanly.
- Standalone reproducer with a canary placed right after the buffer: a 1520-character token wrote 20 bytes past `s_shared_token` before the fix (canary clobbered with `0x4141414141414141`), and is truncated to 1499 bytes after the fix.


---

**Edit:** also fixed a global buffer overflow of the same class in `CBasePlayer::PrioritizeAutoBuyString()`. `priorityToken[32]` is filled from the client-supplied autobuy string without bounds checking, so a single autobuy token longer than 31 characters overflowed it during career-mode auto-buy. Bounded to `sizeof(priorityToken) - 1` matching `ParseAutoBuyString()`, and the rest of an oversized token is skipped so it is not re-split into a spurious priority token.