### PR TITLE
Add `mp_show_hintmessages` cvar to allow blocking hint messages server-side

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This means that plugins that do binary code analysis (Orpheu for example) probab
 | mp_show_radioicon                  | 1       | 0   | 1            | Show radio icon.<br/>`0` disabled<br/>`1` enabled |
 | mp_show_scenarioicon               | 0       | 0   | 1            | Show scenario icon in HUD such as count of alive hostages or ticking bomb.<br/>`0` disabled<br/>`1` enabled |
 | mp_show_bomb_timer                 | 0       | 0   | 1            | Show the time until the planted bomb explodes on the HUD round timer.<br/>`0` disabled<br/>`1` enabled (when the bomb is planted, the round timer shows the C4 countdown) |
-| mp_show_hintmessages               | 1       | 0   | 1            | Send hint messages (Hint_*) to clients.<br/>`0` disabled (hints are blocked server-side)<br/>`1` enabled |
+| mp_show_hintmessages               | 1       | 0   | 1            | Send hint messages (Hint_*) to clients.<br/>`0` disabled (non-forced hints are suppressed server-side; forced hints, e.g. ReAPI `rg_hint_message` with override, still pass)<br/>`1` enabled |
 | mp_old_bomb_defused_sound          | 1       | 0   | 1            | Play "Bomb has been defused" sound instead of "Counter-Terrorists win" when bomb was defused<br/>`0` disabled<br/>`1` enabled |
 | showtriggers                       | 0       | 0   | 1            | Debug cvar shows triggers. |
 | sv_alltalk                         | 0       | 0   | 5            | When players can hear each other ([further explanation](../../wiki/sv_alltalk)).<br/>`0` dead don't hear alive<br/>`1` no restrictions<br/>`2` teammates hear each other<br/>`3` Same as 2, but spectators hear everybody<br/>`4` alive hear alive, dead hear dead and alive.<br/>`5` alive hear alive teammates, dead hear dead and alive.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ This means that plugins that do binary code analysis (Orpheu for example) probab
 | mp_show_radioicon                  | 1       | 0   | 1            | Show radio icon.<br/>`0` disabled<br/>`1` enabled |
 | mp_show_scenarioicon               | 0       | 0   | 1            | Show scenario icon in HUD such as count of alive hostages or ticking bomb.<br/>`0` disabled<br/>`1` enabled |
 | mp_show_bomb_timer                 | 0       | 0   | 1            | Show the time until the planted bomb explodes on the HUD round timer.<br/>`0` disabled<br/>`1` enabled (when the bomb is planted, the round timer shows the C4 countdown) |
+| mp_show_hintmessages               | 1       | 0   | 1            | Send hint messages (Hint_*) to clients.<br/>`0` disabled (hints are blocked server-side)<br/>`1` enabled |
 | mp_old_bomb_defused_sound          | 1       | 0   | 1            | Play "Bomb has been defused" sound instead of "Counter-Terrorists win" when bomb was defused<br/>`0` disabled<br/>`1` enabled |
 | showtriggers                       | 0       | 0   | 1            | Debug cvar shows triggers. |
 | sv_alltalk                         | 0       | 0   | 5            | When players can hear each other ([further explanation](../../wiki/sv_alltalk)).<br/>`0` dead don't hear alive<br/>`1` no restrictions<br/>`2` teammates hear each other<br/>`3` Same as 2, but spectators hear everybody<br/>`4` alive hear alive, dead hear dead and alive.<br/>`5` alive hear alive teammates, dead hear dead and alive.

--- a/dist/game.cfg
+++ b/dist/game.cfg
@@ -206,6 +206,13 @@ mp_show_scenarioicon "0"
 // Default value: "0"
 mp_show_bomb_timer "0"
 
+// Send hint messages (Hint_*) to clients.
+// 0 - disabled (hints are blocked server-side)
+// 1 - enabled (default behavior)
+//
+// Default value: "1"
+mp_show_hintmessages "1"
+
 // Play "Bomb has been defused" sound instead of "Counter-Terrorists win" when bomb was defused
 // 0 - disabled (default behavior)
 // 1 - enabled

--- a/dist/game.cfg
+++ b/dist/game.cfg
@@ -207,7 +207,7 @@ mp_show_scenarioicon "0"
 mp_show_bomb_timer "0"
 
 // Send hint messages (Hint_*) to clients.
-// 0 - disabled (hints are blocked server-side)
+// 0 - disabled (non-forced hints suppressed server-side; forced hints still pass)
 // 1 - enabled (default behavior)
 //
 // Default value: "1"

--- a/regamedll/dlls/game.cpp
+++ b/regamedll/dlls/game.cpp
@@ -128,6 +128,7 @@ cvar_t roundover                    = { "mp_roundover", "0", FCVAR_SERVER, 0.0f,
 cvar_t forcerespawn                 = { "mp_forcerespawn", "0", FCVAR_SERVER, 0.0f, nullptr };
 cvar_t show_radioicon               = { "mp_show_radioicon", "1", 0, 1.0f, nullptr };
 cvar_t show_scenarioicon            = { "mp_show_scenarioicon", "0", FCVAR_SERVER, 0.0f, nullptr };
+cvar_t show_hintmessages            = { "mp_show_hintmessages", "1", 0, 1.0f, nullptr };
 cvar_t old_bomb_defused_sound       = { "mp_old_bomb_defused_sound", "1", 0, 1.0f, nullptr };
 cvar_t item_staytime                = { "mp_item_staytime", "300", FCVAR_SERVER, 300.0f, nullptr };
 cvar_t legacy_bombtarget_touch      = { "mp_legacy_bombtarget_touch", "1", 0, 1.0f, nullptr };
@@ -417,6 +418,7 @@ void EXT_FUNC GameDLLInit()
 		CVAR_REGISTER(&show_scenarioicon);
 	}
 
+	CVAR_REGISTER(&show_hintmessages);
 	CVAR_REGISTER(&old_bomb_defused_sound);
 	CVAR_REGISTER(&item_staytime);
 	CVAR_REGISTER(&legacy_bombtarget_touch);

--- a/regamedll/dlls/game.h
+++ b/regamedll/dlls/game.h
@@ -157,6 +157,7 @@ extern cvar_t roundover;
 extern cvar_t forcerespawn;
 extern cvar_t show_radioicon;
 extern cvar_t show_scenarioicon;
+extern cvar_t show_hintmessages;
 extern cvar_t old_bomb_defused_sound;
 extern cvar_t item_staytime;
 extern cvar_t legacy_bombtarget_touch;

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -8108,6 +8108,11 @@ LINK_HOOK_CLASS_CHAIN(bool, CBasePlayer, HintMessageEx, (const char *pMessage, f
 
 bool EXT_FUNC CBasePlayer::__API_HOOK(HintMessageEx)(const char *pMessage, float duration, bool bDisplayIfPlayerDead, bool bOverride)
 {
+#ifdef REGAMEDLL_ADD
+	if (show_hintmessages.value == 0.0f)
+		return false;
+#endif
+
 	if (!bDisplayIfPlayerDead && !IsAlive())
 		return false;
 

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -8108,13 +8108,16 @@ LINK_HOOK_CLASS_CHAIN(bool, CBasePlayer, HintMessageEx, (const char *pMessage, f
 
 bool EXT_FUNC CBasePlayer::__API_HOOK(HintMessageEx)(const char *pMessage, float duration, bool bDisplayIfPlayerDead, bool bOverride)
 {
-#ifdef REGAMEDLL_ADD
-	if (show_hintmessages.value == 0.0f)
-		return false;
-#endif
-
 	if (!bDisplayIfPlayerDead && !IsAlive())
 		return false;
+
+#ifdef REGAMEDLL_ADD
+	// Server-side sibling of the client's _ah (auto-help) preference: suppresses
+	// non-forced hints only. bOverride still bypasses it, exactly as it already
+	// bypasses m_bShowHints, so ReAPI callers keep their existing escape hatch.
+	if (!bOverride && show_hintmessages.value == 0.0f)
+		return true;
+#endif
 
 	if (bOverride || m_bShowHints)
 		return m_hintMessageQueue.AddMessage(pMessage, duration, true, nullptr);


### PR DESCRIPTION
## What
Adds a new cvar `mp_show_hintmessages` (default `1`) that allows servers to disable sending hint messages (`#Hint_*`) to clients.

## Why
Server operators often want to get rid of the tutorial-style hint popups (e.g. `#Hint_you_have_the_bomb`, `#Hint_spotted_an_enemy`, zone hints). Currently this requires a plugin that hooks `RG_CBasePlayer_HintMessageEx` and supersedes it. Since every hint goes through a single function, this is trivial to support natively.

## How it works
All hint messages are routed through `CBasePlayer::HintMessageEx()` (both directly and via the `HintMessage()` wrapper) before being queued into `m_hintMessageQueue`. When `mp_show_hintmessages` is `0`, `HintMessageEx()` returns `false` immediately, so nothing is queued and nothing is sent to the client. The check is under `REGAMEDLL_ADD`; default value `1` keeps vanilla behavior.

## Edge cases
- Center-print messages (e.g. `#Got_bomb`) are not affected - they are not hints and bypass the hint queue by design.
- The API hookchain `RG_CBasePlayer_HintMessageEx` still fires as before; the cvar check is inside the hooked function body, so plugins keep working.
- The client-side "Auto-Help" setting (`m_bShowHints`) is untouched; the cvar acts as a server-wide override on top of it.

## Tested
Built Win32 Release (MSVC) and verified on a listen/dedicated ReHLDS server: with the cvar at `1` the bomb pickup hint is shown as usual; after `mp_show_hintmessages 0` (changeable at runtime) no hints are delivered, while center messages remain intact.