### PR TITLE
Add `mp_hostage_fear` cvar to control improved hostage AI fear reactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ This means that plugins that do binary code analysis (Orpheu for example) probab
 | mp_timelimit                       | 0       | -   | -            | Period between map rotations.<br />`0` means no limit |
 | mp_forcerespawn                    | 0       | 0   | -            | Players will automatically respawn when killed.<br/>`0` disabled<br/>`>0.00001` time delay to respawn |
 | mp_hostage_hurtable                | 1       | 0   | 1            | The hostages can take damage.<br/>`0` disabled<br/>`1` from any team<br/>`2` only from `CT`<br/>`3` only from `T` |
+| mp_hostage_fear                    | 1       | 0   | 1            | The hostages with improved AI (`hostage_ai_enable 1`) get scared of gunfire, explosions and nearby deaths.<br/>`0` disabled (hostages stay calm)<br/>`1` enabled |
 | mp_show_radioicon                  | 1       | 0   | 1            | Show radio icon.<br/>`0` disabled<br/>`1` enabled |
 | mp_show_scenarioicon               | 0       | 0   | 1            | Show scenario icon in HUD such as count of alive hostages or ticking bomb.<br/>`0` disabled<br/>`1` enabled |
 | mp_old_bomb_defused_sound          | 1       | 0   | 1            | Play "Bomb has been defused" sound instead of "Counter-Terrorists win" when bomb was defused<br/>`0` disabled<br/>`1` enabled |

--- a/dist/game.cfg
+++ b/dist/game.cfg
@@ -177,6 +177,14 @@ mp_forcerespawn "0"
 // Default value: "1"
 mp_hostage_hurtable "1"
 
+// The hostages with improved AI (hostage_ai_enable 1)
+// get scared of gunfire, explosions and nearby deaths.
+// 0 - disabled (hostages stay calm)
+// 1 - enabled (default behaviour)
+//
+// Default value: "1"
+mp_hostage_fear "1"
+
 // Show radio icon.
 // 0 - disabled
 // 1 - enabled (default behavior)

--- a/regamedll/dlls/game.cpp
+++ b/regamedll/dlls/game.cpp
@@ -123,6 +123,7 @@ cvar_t round_restart_delay   = { "mp_round_restart_delay", "5", FCVAR_SERVER, 0.
 cvar_t showtriggers          = { "showtriggers", "0", 0, 0.0f, nullptr }; // debug cvar shows triggers
                                                                           // TODO: Maybe it's better to register in the engine?
 cvar_t hostagehurtable              = { "mp_hostage_hurtable", "1", FCVAR_SERVER, 1.0f, nullptr };
+cvar_t hostagefear                  = { "mp_hostage_fear", "1", FCVAR_SERVER, 1.0f, nullptr };
 cvar_t roundover                    = { "mp_roundover", "0", FCVAR_SERVER, 0.0f, nullptr };
 cvar_t forcerespawn                 = { "mp_forcerespawn", "0", FCVAR_SERVER, 0.0f, nullptr };
 cvar_t show_radioicon               = { "mp_show_radioicon", "1", 0, 1.0f, nullptr };
@@ -403,6 +404,7 @@ void EXT_FUNC GameDLLInit()
 
 	CVAR_REGISTER(&showtriggers);
 	CVAR_REGISTER(&hostagehurtable);
+	CVAR_REGISTER(&hostagefear);
 	CVAR_REGISTER(&roundover);
 	CVAR_REGISTER(&forcerespawn);
 	CVAR_REGISTER(&show_radioicon);

--- a/regamedll/dlls/game.h
+++ b/regamedll/dlls/game.h
@@ -152,6 +152,7 @@ extern cvar_t round_restart_delay;
 
 extern cvar_t showtriggers;
 extern cvar_t hostagehurtable;
+extern cvar_t hostagefear;
 extern cvar_t roundover;
 extern cvar_t forcerespawn;
 extern cvar_t show_radioicon;

--- a/regamedll/dlls/hostage/hostage_improv.cpp
+++ b/regamedll/dlls/hostage/hostage_improv.cpp
@@ -1560,6 +1560,12 @@ bool CHostageImprov::IsScared() const
 
 void CHostageImprov::Frighten(ScareType scare)
 {
+#ifdef REGAMEDLL_ADD
+	// keep hostages calm, they won't get scared of gunfire, explosions or nearby deaths
+	if (hostagefear.value <= 0.0f)
+		return;
+#endif
+
 	const float ignoreTime = 10.0f;
 
 	if (!IsScared())


### PR DESCRIPTION
Addresses the hostage panic/scatter part of #1125.

## What

New cvar `mp_hostage_fear` (default `1` - vanilla behavior) that controls whether hostages driven by the improved AI (`hostage_ai_enable 1`) get scared of gunfire, explosions and nearby deaths. With `mp_hostage_fear 0` hostages stay calm: they don't panic, don't scatter and don't refuse to follow after nearby shooting - CS 1.6-like hostage temperament while keeping the rest of the improved AI (navigation, chatter, animations).

## Why

With `hostage_ai_enable 1` on CS 1.6 hostage maps, any nearby enemy gunfire frightens the hostages (`CHostageImprov::OnGameEvent` -> `Frighten(SCARED/TERRIFIED)`). Scared hostages scatter, crouch and refuse to follow the rescuer, which #1125 reports as disruptive on 1.6 servers, where the original hostages ignore gunfire completely. Server operators currently have no way to keep the improved AI but disable the fear reactions.

## How it works

All fear-driven behavior (fleeing in `HostageIdleState`, refusing to follow, scared/afraid animations) is gated by `CHostageImprov::IsScared()`, which is true only while `m_scaredTimer` is running - and that timer is started exclusively in `CHostageImprov::Frighten()`. So a single early return in `Frighten()` when `mp_hostage_fear` is `0` keeps hostages calm everywhere. The cvar is evaluated on every call, so it can be flipped at runtime without a map change or server restart.

## Edge cases

- Direct damage to a hostage still makes it flee (`OnInjury` -> `m_mustFlee` in the idle state). That path is deliberately not gated: fleeing from an actual injury is self-preservation, distinct from panicking at noise.
- Classic 1.6 hostage AI (`hostage_ai_enable 0`) is unaffected - it has no fear logic at all.
- Default value `1` keeps vanilla behavior; vanilla builds are unaffected (the check is under `#ifdef REGAMEDLL_ADD`).

## Tested

Windows build (MSVC), verified on a ReHLDS server with `hostage_ai_enable 1`:
- `mp_hostage_fear 1` (default): hostages panic, scatter and refuse to follow when a Terrorist fires nearby - unchanged behavior.
- `mp_hostage_fear 0` (set at runtime, no restart): hostages stay calm under fire and keep following normally.