### PR TITLE
Fix VIP unable to receive/pick up the knife

### DIFF
--- a/regamedll/dlls/weapons.cpp
+++ b/regamedll/dlls/weapons.cpp
@@ -626,7 +626,8 @@ void CBasePlayerItem::DefaultTouch(CBaseEntity *pOther)
 		&& m_iId != WEAPON_DEAGLE
 		&& m_iId != WEAPON_KNIFE
 #else
-		!IsSecondaryWeapon(m_iId)
+		m_iId != WEAPON_KNIFE
+		&& !IsSecondaryWeapon(m_iId)
 #endif
 
 		)


### PR DESCRIPTION
### What
On assassination maps the VIP spawns without a knife — only the pistol is given. Picking a knife up from the ground is impossible for a VIP too.

### Why (Root cause)
#1045 replaced the hardcoded VIP pickup allow-list in `CBasePlayerItem::DefaultTouch` with `!IsSecondaryWeapon(m_iId)` in order to also permit the previously-forgotten Five-Seven and Dual Elite. The old list contained an explicit `m_iId != WEAPON_KNIFE` clause. The knife is **not** a secondary weapon, so the new predicate started rejecting it.

`GiveDefaultItems()` hands the knife over via `GiveNamedItem`/`GiveNamedItemEx`, both of which route the entity through `DispatchTouch` → `DefaultTouch`. For a VIP the touch is now rejected, so the knife is never added, while the pistol (a secondary weapon) still passes.

### How it works
Restore the knife exception in the `REGAMEDLL_FIXES` branch:
```cpp
m_iId != WEAPON_KNIFE
&& !IsSecondaryWeapon(m_iId)
```
A VIP may again hold knife + all pistols; primary weapons and grenades stay blocked exactly as before.

### Edge cases
- Non-VIP players are unaffected — the whole block is guarded by `m_bIsVIP`.
- Vanilla build (`#ifndef REGAMEDLL_FIXES`) is untouched; it already listed the knife explicitly.
- Applies both to default spawn equipment and to picking a knife up off the ground.

### Tested
Built with MSVC (PlatformToolset v145, Release/Win32). Reproduction on an `as_*` map: before the change the VIP spawns with a pistol but no knife; after the change the knife is present again and can be selected.