### PR TITLE
Fix HP recovery after surfacing when drowning with DAMAGE_NO

### DIFF
--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -3240,13 +3240,14 @@ void CBasePlayer::WaterMove()
 				if (pev->dmg > 5)
 					pev->dmg = 5;
 
-				TakeDamage(VARS(eoNullEntity), VARS(eoNullEntity), pev->dmg, DMG_DROWN);
-
 #ifdef REGAMEDLL_FIXES
-				// NOTE: If we died after the damage of above and was followed respawn,
-				// so we should get out of code.
-				if (!(m_bitsDamageType & DMG_DROWN))
+				// Don't track drowning damage that wasn't actually applied (player is
+				// invulnerable/DAMAGE_NO, or died from it and possibly respawned) -
+				// otherwise it would be "given back" as free health when surfacing.
+				if (!TakeDamage(VARS(eoNullEntity), VARS(eoNullEntity), pev->dmg, DMG_DROWN))
 					return;
+#else
+				TakeDamage(VARS(eoNullEntity), VARS(eoNullEntity), pev->dmg, DMG_DROWN);
 #endif
 
 				pev->pain_finished = gpGlobals->time + 1;


### PR DESCRIPTION
Fixes #1111

## What
Drowning damage that is refused because the player is invulnerable (`pev->takedamage == DAMAGE_NO`) is still tracked as drowning damage, so it gets "given back" as free health once the player surfaces.

## Why (Root cause)
Drowning damage is accumulated in `m_idrowndmg` and later restored to health via `DMG_DROWNRECOVER` when the player takes a breath. That tracker must only ever hold damage that was actually applied.

`CBaseMonster::TakeDamage` refuses the damage and returns `FALSE` when `pev->takedamage == DAMAGE_NO`, without touching health. But the wrapper `CBasePlayer::TakeDamage` still runs to the end and unconditionally sets the damage-type bit:

```cpp
// player.cpp, end of CBasePlayer::TakeDamage
m_bitsDamageType |= bitsDamageType;
```

The existing guard in `WaterMove()` relied on that bit:

```cpp
TakeDamage(VARS(eoNullEntity), VARS(eoNullEntity), pev->dmg, DMG_DROWN);
if (!(m_bitsDamageType & DMG_DROWN))
    return;
```

Because the bit is set even for refused damage, the guard passes and `m_idrowndmg += pev->dmg` accumulates phantom damage. On surfacing that phantom amount is restored as free health, up to `max_health`.

## How it works
Gate the tracking on the actual return value of `TakeDamage` instead of the side-effect bit. `TakeDamage` returns `FALSE` both when the damage is refused (`DAMAGE_NO`) and when the tick was lethal (`CBaseMonster::TakeDamage` returns `FALSE` after killing the player) - which is exactly when the damage must not be tracked. This also keeps the original intent of the previous guard (don't track if we died and possibly respawned).

## Edge cases
- Vulnerable player drowning normally: unchanged - damage is applied, tracked, and recovered on surfacing as before.
- Lethal drowning tick / respawn: not tracked (return value is `FALSE`), same as the previous guard intended.
- Non-`REGAMEDLL_FIXES` builds: behavior unchanged; the guard lives under `REGAMEDLL_FIXES`.

## Tested
- Vulnerable dive/surface: only the real drowning loss is recovered (fall to 25 HP, drown to 13, surface back to 25 - the fall damage is not restored).
- Invulnerable dive with `takedamage = DAMAGE_NO` set via reapi: HP no longer climbs on surfacing (before the fix it recovered free health up to `max_health`).
