### PR TITLE
Fix: transient info_map_parameters permanently orphans g_pMapInfo

### DIFF
--- a/regamedll/dlls/mapinfo.cpp
+++ b/regamedll/dlls/mapinfo.cpp
@@ -22,7 +22,9 @@ void CMapInfo::OnCreate()
 
 void CMapInfo::OnDestroy()
 {
-	g_pMapInfo = nullptr;
+	// Only the instance that owns the global may clear it.
+	if (g_pMapInfo == this)
+		g_pMapInfo = nullptr;
 }
 
 void CMapInfo::CheckMapInfo()


### PR DESCRIPTION
## Problem: a second `info_map_parameters` disables the map's real one

The map settings get clobbered, allowing players to buy on maps they shouldn't. It also resets `bombradius` to default (500).

`CMapInfo::OnCreate()` is first-wins, but `OnDestroy()` clears the global unconditionally:

```cpp
void CMapInfo::OnCreate()
{
    ...
    if (g_pMapInfo)
        ALERT(at_warning, "Warning: Multiple info_map_parameters entities in map!\n");
    else
        g_pMapInfo = this;
}

void CMapInfo::OnDestroy()
{
    g_pMapInfo = nullptr;
}
```

So any second instance of `info_map_parameters`  nulls `g_pMapInfo` even though it never owned it.

The map's real entity is orphaned, as both `CheckMapInfo()` call sites sit behind `if (g_pMapInfo)`, so they are skipped for the rest of the map.

I hit this from [an AMXX plugin](https://forums.alliedmods.net/showpost.php?p=2845421&postcount=120).

HamSandwich evidently resolves a classname's vtable by creating a throwaway entity of that class, so `RegisterHam(Ham_TraceAttack, "info_map_parameters", ...)` was enough to trigger the bug.

**Fix:** one line lol, only let the instance that owns the global clear it.

```diff
 void CMapInfo::OnDestroy()
 {
-    g_pMapInfo = nullptr;
+    if (g_pMapInfo == this)
+        g_pMapInfo = nullptr;
 }
```

The guard was in the original `~CMapInfo()`, dropped in `183a9f6` with the virtual destructor, and omitted when the destructor returned in `49c64e4`.

### Demonstration

- Server set to `developer 1` and running `aim_map.bsp` (which has the `buying 3` param, and no `func_buyzone` ents).
  
- Three test plugins: [buycheck](https://pastebin.com/E8iiTVsm), [buyfix](https://pastebin.com/zfsYkxi4), and [buybug](https://pastebin.com/2nFsqbEB) (note: [Advanced Weapon Tracers](https://forums.alliedmods.net/showthread.php?p=2845421) can be used instead of buybug).
  

Normal, expected behavior on `aim_map` is to see `No one can buy!!` in the server console, and a buycheck that looks like this:

```
========== [buycheck] map=aim_map ==========
[buycheck]   ent #33  buying=3 = NO ONE can buy  bombradius=500
[buycheck] 1 info_map_parameters (ent #33)
[buycheck] gamerules: m_bTCantBuy=1  m_bCTCantBuy=1  m_bMapHasBuyZone=0
[buycheck] VERDICT: Ts can buy = NO | CTs can buy = NO
```

When we introduce buybug.amxx (or the tracers), the console emits this instead:

`WARNING: Warning: Multiple info_map_parameters entities in map!`

and buycheck shows:

```
========== [buycheck] map=aim_map ==========
[buycheck]   ent #33  buying=3 = NO ONE can buy  bombradius=500
[buycheck] 1 info_map_parameters (ent #33)
[buycheck] gamerules: m_bTCantBuy=0  m_bCTCantBuy=0  m_bMapHasBuyZone=0
[buycheck] VERDICT: Ts can buy = yes | CTs can buy = yes
[buycheck] --> g_pMapInfo is null.
```

The gamerules got smashed to bits, so everyone can buy on `aim_map` all of a sudden. 

Buyfix saves `m_bTCantBuy/m_bCTCantBuy` from obliteration, buycheck passes, and the map plays as it should.

### Result

✓ Patched mp.dll doesn't null `g_pMapInfo`, even with the bugged plugin active (`developer 1` warning preserved).

This bug probably bit often due to the popularity of Advanced Weapon Tracers lol.