### PR TITLE
regamedll: remove -s strip flag to preserve linker markers

### DIFF
--- a/regamedll/CMakeLists.txt
+++ b/regamedll/CMakeLists.txt
@@ -41,7 +41,7 @@ set(LINK_LIBS dl)
 
 # do not strip debuginfo during link
 if (NOT DEBUG)
-	set(LINK_FLAGS "-s")
+	set(LINK_FLAGS "")
 endif()
 
 # add -m32 flag only on 64-bit systems, if building for 64-bit wasn't enabled with XASH_COMPAT


### PR DESCRIPTION
## Problem

`LINK_FLAGS` is initialized to `"-s"` in the non-debug branch, which causes `strip` to run on the output shared library. This removes all symbols including sentinel symbols used by packaging systems to verify that `LDFLAGS` were respected. For example, Gentoo injects `--defsym=__gentoo_check_ldflags__=0` into `LDFLAGS` and checks the resulting binary still contains it — `-s` destroys that symbol, causing a QA failure.

## Fix

Replace `set(LINK_FLAGS "-s")` with `set(LINK_FLAGS "")`. Stripping should be left to the build system or packager.

## Related

Same issue was fixed in sibling projects under the same vendor:
- rehlds/Metamod-R#93
- rehlds/ReHLDS#1194 (which removed hardcoded `-flto` from HLTV components with the same non-PIC i386 pattern)