### PR TITLE
regamedll: allow text relocations for non-PIC i386 shared library

### DIFF
--- a/regamedll/CMakeLists.txt
+++ b/regamedll/CMakeLists.txt
@@ -417,6 +417,8 @@ if (CMAKE_SIZEOF_VOID_P EQUAL 4)
 	set(LINK_FLAGS "${LINK_FLAGS} -L${PROJECT_SOURCE_DIR}/lib/linux32")
 endif()
 
+set(LINK_FLAGS "${LINK_FLAGS} -Wl,-z,notext")
+
 set_target_properties(regamedll PROPERTIES
 	COMPILE_FLAGS ${COMPILE_FLAGS}
 	LINK_FLAGS ${LINK_FLAGS}
@@ -424,15 +426,21 @@ set_target_properties(regamedll PROPERTIES
 
 if (XASH_COMPAT)
 	if (CMAKE_SYSTEM_NAME STREQUAL "Android")
-		set_target_properties(regamedll PROPERTIES
+		set(LINK_FLAGS "${LINK_FLAGS} -Wl,-z,notext")
+
+set_target_properties(regamedll PROPERTIES
 			OUTPUT_NAME server)
 	else()
-		set_target_properties(regamedll PROPERTIES
+		set(LINK_FLAGS "${LINK_FLAGS} -Wl,-z,notext")
+
+set_target_properties(regamedll PROPERTIES
 			PREFIX ""
 			OUTPUT_NAME cs${POSTFIX})
 	endif()
 else()
-	set_target_properties(regamedll PROPERTIES
+	set(LINK_FLAGS "${LINK_FLAGS} -Wl,-z,notext")
+
+set_target_properties(regamedll PROPERTIES
 		OUTPUT_NAME cs
 		PREFIX ""
 		POSITION_INDEPENDENT_CODE OFF)


### PR DESCRIPTION
## Problem

The library is built with `POSITION_INDEPENDENT_CODE OFF`, producing non-PIC i386 objects that contain relocations in read-only `.text` sections (text relocations). Modern ld (≥ 2.36) rejects these by default:

```
ld: warning: relocation against '...' in read-only section '.text'
ld: read-only segment has dynamic relocations
collect2: error: ld returned 1 exit status
```

## Fix

Add `-Wl,-z,notext` to `LINK_FLAGS` before `set_target_properties`, restoring the historical linker behaviour that permits text relocations — matching the original intent of `POSITION_INDEPENDENT_CODE OFF`.

## Related

The identical fix was applied to the sibling project for all six non-PIC i386 shared libraries it ships:
- rehlds/ReHLDS#1195