### PR TITLE
Use sv_zmax for player ID trace range instead of hardcoded MAX_ID_RANGE

### DIFF
--- a/regamedll/dlls/game.cpp
+++ b/regamedll/dlls/game.cpp
@@ -10,6 +10,7 @@ cvar_t *g_psv_stopspeed   = nullptr;
 cvar_t *g_psv_stepsize    = nullptr;
 cvar_t *g_psv_clienttrace = nullptr;
 cvar_t *g_psv_maxvelocity = nullptr;
+cvar_t *g_psv_zmax        = nullptr;
 
 cvar_t displaysoundlist      = { "displaysoundlist", "0", 0, 0.0f, nullptr };
 cvar_t timelimit             = { "mp_timelimit", "0", FCVAR_SERVER, 0.0f, nullptr };
@@ -272,6 +273,7 @@ void EXT_FUNC GameDLLInit()
 	g_psv_stepsize    = CVAR_GET_POINTER("sv_stepsize");
 	g_psv_clienttrace = CVAR_GET_POINTER("sv_clienttrace");
 	g_psv_maxvelocity = CVAR_GET_POINTER("sv_maxvelocity");
+	g_psv_zmax        = CVAR_GET_POINTER("sv_zmax");
 
 	CVAR_REGISTER(&displaysoundlist);
 	CVAR_REGISTER(&timelimit);

--- a/regamedll/dlls/game.h
+++ b/regamedll/dlls/game.h
@@ -50,6 +50,7 @@ extern cvar_t *g_psv_stopspeed;
 extern cvar_t *g_psv_stepsize;
 extern cvar_t *g_psv_clienttrace;
 extern cvar_t *g_psv_maxvelocity;
+extern cvar_t *g_psv_zmax;
 
 extern cvar_t displaysoundlist;
 extern cvar_t timelimit;

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -8252,7 +8252,13 @@ void EXT_FUNC CBasePlayer::__API_HOOK(UpdateStatusBar)()
 	UTIL_MakeVectors(pev->v_angle + pev->punchangle);
 
 	Vector vecSrc = EyePosition();
-	Vector vecEnd = vecSrc + (gpGlobals->v_forward * ((pev->flags & FL_SPECTATOR) != 0 ? MAX_SPEC_ID_RANGE : MAX_ID_RANGE));
+	Vector vecEnd = vecSrc + (gpGlobals->v_forward * ((pev->flags & FL_SPECTATOR) != 0 ? MAX_SPEC_ID_RANGE :
+#ifdef REGAMEDLL_ADD
+		(g_psv_zmax ? g_psv_zmax->value : MAX_ID_RANGE)
+#else
+		MAX_ID_RANGE
+#endif
+	));
 
 	UTIL_TraceLine(vecSrc, vecEnd, dont_ignore_monsters, edict(), &tr);
 


### PR DESCRIPTION
## Summary
- Use existing engine CVar `sv_zmax` (render distance) for the player ID trace range instead of the hardcoded `MAX_ID_RANGE = 2048.0f`
- On large maps (e.g. de_abaddon), player nicknames are now visible at the same distance as the map's render range
- Added `g_psv_zmax` pointer in `game.h`/`game.cpp`, initialized via `CVAR_GET_POINTER("sv_zmax")` in `GameDLLInit()`
- Falls back to `MAX_ID_RANGE` (2048) if `sv_zmax` is not available
- Spectator range (`MAX_SPEC_ID_RANGE = 8192`) is unchanged
- Wrapped in `#ifdef REGAMEDLL_ADD` for backward compatibility

Fixes #726