### PR TITLE
Fix func_vehicle engine sound issues

### DIFF
--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -4281,7 +4281,19 @@ void CBasePlayer::PlayerUse()
 				if (legacy_vehicle_block.value == 0)
 					return;
 #endif
-				((CFuncVehicle *)pTrain)->m_pDriver = nullptr;
+				CFuncVehicle *pVehicle = (CFuncVehicle *)pTrain;
+				pVehicle->m_pDriver = nullptr;
+#ifdef REGAMEDLL_FIXES
+				if (Q_abs(pTrain->pev->speed) < 50)
+				{
+					pVehicle->StopSound();
+					pVehicle->SetThink(nullptr);
+					pTrain->pev->speed = 0;
+					pTrain->pev->velocity = g_vecZero;
+					pTrain->pev->avelocity = g_vecZero;
+					pVehicle->m_fEngineOn = FALSE;
+				}
+#endif
 			}
 			return;
 		}
@@ -4299,8 +4311,18 @@ void CBasePlayer::PlayerUse()
 
 				if (pTrain->Classify() == CLASS_VEHICLE)
 				{
+					CFuncVehicle *pVehicle = (CFuncVehicle *)pTrain;
+#ifdef REGAMEDLL_FIXES
+					if (!pVehicle->m_fEngineOn)
+					{
+						EMIT_SOUND(ENT(pev), CHAN_ITEM, "plats/vehicle_ignition.wav", 0.8, ATTN_NORM);
+						pVehicle->m_fEngineOn = TRUE;
+						pVehicle->UpdateSound();
+					}
+#else
 					EMIT_SOUND(ENT(pev), CHAN_ITEM, "plats/vehicle_ignition.wav", 0.8, ATTN_NORM);
-					((CFuncVehicle *)pTrain)->m_pDriver = this;
+#endif
+					pVehicle->m_pDriver = this;
 				}
 				else
 					EMIT_SOUND(ENT(pev), CHAN_ITEM, "plats/train_use1.wav", 0.8, ATTN_NORM);

--- a/regamedll/dlls/trains.h
+++ b/regamedll/dlls/trains.h
@@ -198,6 +198,10 @@ public:
 	Vector m_vSurfaceNormal;
 	Vector m_vVehicleDirection;
 	CBaseEntity *m_pDriver;
+#ifdef REGAMEDLL_FIXES
+	int m_iCollisionCount;
+	BOOL m_fEngineOn;
+#endif
 
 private:
 	unsigned short m_usAdjustPitch;

--- a/regamedll/dlls/vehicle.cpp
+++ b/regamedll/dlls/vehicle.cpp
@@ -441,6 +441,9 @@ void CFuncVehicle::CollisionDetection()
 
 				if (tr.flFraction == 1.0f)
 				{
+#ifdef REGAMEDLL_FIXES
+					m_iCollisionCount = 0;
+#endif
 					return;
 				}
 			}
@@ -454,6 +457,16 @@ void CFuncVehicle::CollisionDetection()
 			}
 			else if (tr.vecPlaneNormal.z < 0.65 || tr.fStartSolid)
 			{
+#ifdef REGAMEDLL_FIXES
+				m_iCollisionCount++;
+				if (m_iCollisionCount >= 3)
+				{
+					pev->speed = 0;
+					pev->velocity = g_vecZero;
+					pev->avelocity = g_vecZero;
+				}
+				else
+#endif
 				pev->speed *= -1.0;
 			}
 			else
@@ -472,6 +485,16 @@ void CFuncVehicle::CollisionDetection()
 			}
 			else if (tr.vecPlaneNormal[2] < 0.65f || tr.fStartSolid)
 			{
+#ifdef REGAMEDLL_FIXES
+				m_iCollisionCount++;
+				if (m_iCollisionCount >= 3)
+				{
+					pev->speed = 0;
+					pev->velocity = g_vecZero;
+					pev->avelocity = g_vecZero;
+				}
+				else
+#endif
 				pev->speed *= -1.0;
 			}
 			else
@@ -502,6 +525,9 @@ void CFuncVehicle::CollisionDetection()
 
 				if (tr.flFraction == 1.0f)
 				{
+#ifdef REGAMEDLL_FIXES
+					m_iCollisionCount = 0;
+#endif
 					return;
 				}
 			}
@@ -516,6 +542,16 @@ void CFuncVehicle::CollisionDetection()
 		}
 		else if (tr.vecPlaneNormal.z < 0.65 || tr.fStartSolid)
 		{
+#ifdef REGAMEDLL_FIXES
+			m_iCollisionCount++;
+			if (m_iCollisionCount >= 3)
+			{
+				pev->speed = 0;
+				pev->velocity = g_vecZero;
+				pev->avelocity = g_vecZero;
+			}
+			else
+#endif
 			pev->speed *= -1.0;
 		}
 		else
@@ -598,6 +634,12 @@ void CFuncVehicle::Next()
 		m_iTurnAngle = 0;
 		pev->avelocity = g_vecZero;
 		pev->velocity = g_vecZero;
+
+#ifdef REGAMEDLL_FIXES
+		// Ensure idle sound is playing when vehicle stops
+		if (m_fEngineOn && !m_soundPlaying)
+			UpdateSound();
+#endif
 
 		SetThink(&CFuncVehicle::Next);
 		NextThink(pev->ltime + time, TRUE);
@@ -805,8 +847,13 @@ void CFuncVehicle::Find()
 	UTIL_SetOrigin(pev, nextPos);
 	NextThink(pev->ltime + 0.1, FALSE);
 	SetThink(&CFuncVehicle::Next);
+#ifdef REGAMEDLL_FIXES
+	if (m_fEngineOn)
+		pev->speed = m_startSpeed;
+#else
 	pev->speed = m_startSpeed;
 	UpdateSound();
+#endif
 }
 
 void CFuncVehicle::NearestPath()
@@ -902,6 +949,10 @@ void CFuncVehicle::Spawn()
 
 	m_dir = 1;
 	m_flTurnStartTime = -1;
+#ifdef REGAMEDLL_FIXES
+	m_iCollisionCount = 0;
+	m_fEngineOn = FALSE;
+#endif
 
 	if (FStringNull(pev->target))
 	{
@@ -946,6 +997,10 @@ void CFuncVehicle::Restart()
 	m_flTurnStartTime = -1;
 	m_flUpdateSound = -1;
 	m_pDriver = nullptr;
+#ifdef REGAMEDLL_FIXES
+	m_iCollisionCount = 0;
+	m_fEngineOn = FALSE;
+#endif
 
 	if (FStringNull(pev->target))
 	{
@@ -954,6 +1009,9 @@ void CFuncVehicle::Restart()
 
 	UTIL_SetOrigin(pev, pev->oldorigin);
 	STOP_SOUND(ENT(pev), CHAN_STATIC, (char *)STRING(pev->noise));
+#ifdef REGAMEDLL_FIXES
+	m_soundPlaying = 0;
+#endif
 
 	NextThink(pev->ltime + 0.1f, FALSE);
 	SetThink(&CFuncVehicle::Find);


### PR DESCRIPTION
## Summary

Fix multiple engine sound issues with `func_vehicle`.

### Bugs fixed

1. **Engine sound playing at map start / round restart** — `Find()` called `UpdateSound()` unconditionally during initialization, starting the engine loop even when no player was in the vehicle. Now `Find()` only sets `m_startSpeed` if the engine is actually running (`m_fEngineOn`).

2. **Engine sound not stopping on round restart** — `Restart()` called `STOP_SOUND` directly but never reset `m_soundPlaying` flag, leaving it stale. Subsequent `UpdateSound()` calls took the wrong branch. Added `m_soundPlaying = 0` after `STOP_SOUND` in `Restart()`.

3. **No idle engine sound when vehicle is stationary** — When the vehicle decelerated to speed 0, `Next()` returned early without ensuring the idle sound was playing. Added `UpdateSound()` call in the speed==0 branch when `m_fEngineOn && !m_soundPlaying`.

4. **Ignition sound playing when entering an already-running vehicle** — `vehicle_ignition.wav` played every time a player entered, even if the engine was already idling. Now the ignition sound only plays when `!m_fEngineOn`.

5. **No idle sound after entering a vehicle** — After entering and starting the vehicle, there was silence until the player actually moved. Now `UpdateSound()` is called on entry to start the idle engine sound immediately.

6. **Vehicle stopping at full speed on +use exit** — When a player exited a moving vehicle, it stopped instantly. Now the vehicle only stops if `|speed| < 50`; at higher speeds the driver is detached but the vehicle coasts to a stop via accelerator decay.

7. **Lost idle sound when backing into a wall** — `CollisionDetection()` reversed speed (`speed *= -1`) on wall hits. If the player kept holding gas, speed oscillated and never reached 0, so idle sound never triggered. Added a collision counter — after 3 consecutive reversals, speed is forced to 0.

### Implementation details

- All changes guarded under `#ifdef REGAMEDLL_FIXES` for backward compatibility
- New members `m_fEngineOn` (engine state) and `m_iCollisionCount` (stuck detection) added to `CFuncVehicle`
- `m_fEngineOn` tracks whether the engine has been started by a player, separate from movement state (`pev->speed`)

Fixes #884