### PR TITLE
Add documentation for undocumented cvars (game.cfg / README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ This means that plugins that do binary code analysis (Orpheu for example) probab
 | mp_freezetime_jump                 | 1       | 0   | 1            | Allow players to jump during freezetime.<br/> `0` disabled<br/>`1` enabled |
 | mp_defuser_allocation              | 0       | 0   | 2            | Give defuser on player spawn.<br/> `0` disabled<br/>`1` Random players. <br/>`2` All players. |
 | mp_location_area_info              | 0       | 0   | 3            | Enable location area info.<br/> `0` disabled<br/>`1` show location below HUD radar.<br/>`2` show location in HUD chat. `NOT RECOMMENDED!` [:speech_balloon:](## "Not all client builds are compatible")<br/>`3` both displayed. `NOT RECOMMENDED!` [:speech_balloon:](## "Not all client builds are compatible")<br/><br/>`NOTE`: Navigation `maps/.nav` file required and should contain place names<br/>`NOTE`: If option `2` or `3` is enabled, be sure to enable `mp_chat_loc_fallback 1` |
+| mp_chat_loc_fallback               | 1       | 0   | 1            | Send pre-formatted colored text with location name in HUD chat and radio messages, instead of localized string tokens (`#Cstrike_Chat_CT_Loc`, `#Game_radio_location`).<br/>Used for compatibility with old client builds that do not know these tokens.<br/>Works in conjunction with `mp_location_area_info 2` or `3`<br/>`0` disabled<br/>`1` enabled |
 | mp_item_respawn_time               | 30      | 0.0 | -            | The respawn time for items (such as health packs, armor, etc.). |
 | mp_weapon_respawn_time             | 20      | 0.0 | -            | The respawn time for weapons. |
 | mp_ammo_respawn_time               | 20      | 0.0 | -            | The respawn time for ammunition. |
@@ -146,6 +147,10 @@ This means that plugins that do binary code analysis (Orpheu for example) probab
 | mp_playerid_field                  | 3       | 0   | 3            | Player ID field display mode.<br/>`0` don't show additional information<br/>`1` show team name<br/>`2` show health percentage<br/>`3` show both team name and health percentage |
 | mp_knockback                       | 170     | -   | -            | Knockback force applied to the victim when damaged by strong weapons (e.g. `AWP`, `AK47`).<br/>Works only if not crouching, and not hit in the legs.<br/>Set to `0` to disable. |
 | mp_knife_wall_sparks               | 0       | 0   | 1            | Show a spark effect at the point of impact when a knife hits a wall.<br/>`0` disabled<br/>`1` enabled |
+| bot_mimic                          | 0       | 0   | -            | Bot repeats all movements of the specified player by client index.<br/>Only alive human players can be mimicked, bots and dead players are ignored<br/>`0` disabled<br/>`>0` client index of the player to mimic |
+| bot_mimic_yaw_offset               | 0       | -   | -            | Yaw offset applied to view angles when bot mimics player movements. (in degrees) |
+| hostage_debug                      | 0       | 0   | -            | Debug output for hostages with improved AI. `NOTE`: Requires `hostage_ai_enable 1` in `game_init.cfg` |
+| hostage_stop                       | 0       | 0   | 1            | Stops movement of the hostages with improved AI. `NOTE`: Requires `hostage_ai_enable 1` in `game_init.cfg`<br/>`0` disabled<br/>`1` enabled |
 
 </details>
 

--- a/dist/game.cfg
+++ b/dist/game.cfg
@@ -619,6 +619,16 @@ mp_defuser_allocation  "0"
 // Default value: "0"
 mp_location_area_info "0"
 
+// Send pre-formatted colored text with location name in HUD chat and radio messages,
+// instead of localized string tokens (#Cstrike_Chat_CT_Loc, #Game_radio_location).
+// Used for compatibility with old client builds that do not know these tokens.
+// Works in conjunction with mp_location_area_info 2 or 3.
+// 0 - disabled (send localized string token)
+// 1 - enabled (default behaviour)
+//
+// Default value: "1"
+mp_chat_loc_fallback "1"
+
 // The respawn time for items (such as health packs, armor, etc.).
 // 0 - disable delay
 //
@@ -720,3 +730,38 @@ mp_knockback "170"
 //
 // Default value: "0"
 mp_knife_wall_sparks "0"
+
+// Log kills to the server log file (logs/L<month><day>.log)
+// NOTE: Affects only log files, death messages on the clients are not affected
+// 0 - disabled
+// 1 - enabled (default behaviour)
+//
+// Default value: "1"
+mp_logkills "1"
+
+// Bot repeats all movements of the specified player. (by client index)
+// NOTE: Only alive human players can be mimicked, bots and dead players are ignored
+// 0 - disabled (default behaviour)
+// >0 - client index of the player to mimic
+//
+// Default value: "0"
+bot_mimic "0"
+
+// Yaw offset applied to view angles when bot mimics player movements. (in degrees)
+//
+// Default value: "0"
+bot_mimic_yaw_offset "0"
+
+// Enable debug output for hostages with improved AI. (see hostage_ai_enable in game_init.cfg)
+// 0 - disabled (default behaviour)
+// 1 - enabled
+//
+// Default value: "0"
+hostage_debug "0"
+
+// Stops movement of the hostages with improved AI. (see hostage_ai_enable in game_init.cfg)
+// 0 - disabled (default behaviour)
+// 1 - enabled
+//
+// Default value: "0"
+hostage_stop "0"


### PR DESCRIPTION
## Summary
Systematic comparison of all cvar definitions in the codebase (`dlls/game.cpp`, `bot/cs_bot_init.cpp`, `hostage/hostage.cpp`, `tutor.cpp`, `voice_gamemgr.cpp`) against `README.md`, `dist/game.cfg` and `dist/game_init.cfg` revealed several cvars missing from the documentation:

- **`mp_chat_loc_fallback`** — had no own entry anywhere; was only mentioned inside the NOTE of `mp_location_area_info`. Added a standalone block next to it in game.cfg and a table row in README.
- **`mp_logkills`** — documented in README but missing from `dist/game.cfg`.
- **`bot_mimic`** / **`bot_mimic_yaw_offset`** — REGAMEDLL_ADD debug cvars (registered in `Bot_RegisterCVars()` under `#ifdef REGAMEDLL_ADD`), never documented anywhere.
- **`hostage_debug`** / **`hostage_stop`** — debug cvars for improved CZ hostage AI, never documented anywhere. Noted that they require `hostage_ai_enable 1`.

Not included: `game_version` (informational cvar, intentionally left undocumented).

Both files updated in the existing documentation style. No code changes.
