### PR TITLE
Mitigate ED_Alloc crashes caused by disposable entity accumulation

### DIFF
--- a/regamedll/dlls/API/CAPI_Impl.cpp
+++ b/regamedll/dlls/API/CAPI_Impl.cpp
@@ -402,4 +402,18 @@ bool CReGameApi::BGetIGameRules(const char *pchVersion) const
 	return false;
 }
 
+void CReGameApi::QueueHudMessage(int client, const struct hudtextparms_s &textparms, const char *pMessage)
+{
+	if (client == 0)
+	{
+		UTIL_HudMessageAll(textparms, pMessage);
+	}
+	else
+	{
+		CBaseEntity *pPlayer = UTIL_PlayerByIndex(client);
+		if (pPlayer)
+			UTIL_HudMessage(pPlayer, textparms, pMessage);
+	}
+}
+
 EXPOSE_SINGLE_INTERFACE(CReGameApi, IReGameApi, VRE_GAMEDLL_API_VERSION);

--- a/regamedll/dlls/API/CAPI_Impl.cpp
+++ b/regamedll/dlls/API/CAPI_Impl.cpp
@@ -406,13 +406,14 @@ void CReGameApi::QueueHudMessage(int client, const struct hudtextparms_s &textpa
 {
 	if (client == 0)
 	{
-		UTIL_HudMessageAll(textparms, pMessage);
+		for (int i = 1; i <= gpGlobals->maxClients; i++)
+		{
+			g_HudQueue.QueueMessage(i, textparms, pMessage);
+		}
 	}
 	else
 	{
-		CBaseEntity *pPlayer = UTIL_PlayerByIndex(client);
-		if (pPlayer)
-			UTIL_HudMessage(pPlayer, textparms, pMessage);
+		g_HudQueue.QueueMessage(client, textparms, pMessage);
 	}
 }
 

--- a/regamedll/dlls/API/CAPI_Impl.h
+++ b/regamedll/dlls/API/CAPI_Impl.h
@@ -1116,4 +1116,5 @@ public:
 	EXT_FUNC virtual AmmoInfoStruct *GetAmmoInfoEx(const char *ammoName);
 	EXT_FUNC virtual bool BGetICSEntity(const char *pchVersion) const;
 	EXT_FUNC virtual bool BGetIGameRules(const char *pchVersion) const;
+	EXT_FUNC virtual void QueueHudMessage(int client, const struct hudtextparms_s &textparms, const char *pMessage);
 };

--- a/regamedll/dlls/client.cpp
+++ b/regamedll/dlls/client.cpp
@@ -1,4 +1,6 @@
 #include "precompiled.h"
+#include "weapons.h"
+#include "gamerules.h"
 
 int gmsgWeapPickup = 0;
 int gmsgHudText = 0;
@@ -3924,6 +3926,60 @@ void EXT_FUNC ParmsChangeLevel()
 	}
 }
 
+extern cvar_t entity_gc;
+
+void CollectGarbage()
+{
+	if (entity_gc.value <= 0.0f)
+		return;
+
+	// Check if we are near the max entities limit
+	if (NUMBER_OF_ENTITIES() < (gpGlobals->maxEntities - ENTITY_INTOLERANCE))
+		return;
+
+	int count = 0;
+	// We iterate from oldest (lowest index) to newest
+	for (int i = 1; i < gpGlobals->maxEntities; i++)
+	{
+		edict_t *pEdict = INDEXENT(i);
+		if (!pEdict || pEdict->free)
+			continue;
+
+		CBaseEntity *pEntity = CBaseEntity::Instance(pEdict);
+		if (!pEntity)
+			continue;
+
+		if (FClassnameIs(pEdict, "weaponbox"))
+		{
+			CWeaponBox *pBox = (CWeaponBox *)pEntity;
+			if (pBox->m_bIsBomb)
+				continue; // DO NOT remove the C4!
+
+			UTIL_Remove(pEntity);
+			count++;
+		}
+		else if (FClassnameIs(pEdict, "weapon_shield"))
+		{
+			UTIL_Remove(pEntity);
+			count++;
+		}
+		else if (FClassnameIs(pEdict, "gib"))
+		{
+			UTIL_Remove(pEntity);
+			count++;
+		}
+
+		// Stop if we cleared enough entities (e.g., 50 entities) to avoid lagging the server by doing too much at once
+		if (count >= 50)
+			break;
+	}
+
+	if (count > 0)
+	{
+		ALERT(at_console, "Garbage Collector: Removed %d old entities to prevent server crash.\n", count);
+	}
+}
+
 void EXT_FUNC StartFrame()
 {
 	if (g_pGameRules)
@@ -3932,6 +3988,8 @@ void EXT_FUNC StartFrame()
 		if (g_pGameRules->IsGameOver())
 			return;
 	}
+
+	CollectGarbage();
 
 	CLocalNav::Think();
 

--- a/regamedll/dlls/client.cpp
+++ b/regamedll/dlls/client.cpp
@@ -3910,7 +3910,7 @@ void EXT_FUNC PlayerPostThink(edict_t *pEntity)
 
 void EXT_FUNC ParmsNewLevel()
 {
-	;
+	g_HudQueue.Reset();
 }
 
 void EXT_FUNC ParmsChangeLevel()
@@ -3933,6 +3933,7 @@ void EXT_FUNC StartFrame()
 			return;
 	}
 
+	g_HudQueue.Think();
 	CLocalNav::Think();
 
 	gpGlobals->teamplay = 1.0f;

--- a/regamedll/dlls/game.cpp
+++ b/regamedll/dlls/game.cpp
@@ -22,6 +22,7 @@ cvar_t fragsleft             = { "mp_fragsleft", "0", FCVAR_SERVER | FCVAR_UNLOG
 cvar_t timeleft              = { "mp_timeleft", "0", FCVAR_SERVER | FCVAR_UNLOGGED, 0.0f, nullptr };
 
 cvar_t friendlyfire          = { "mp_friendlyfire", "0", FCVAR_SERVER, 0.0f, nullptr };
+cvar_t entity_gc             = { "mp_entity_gc", "1", 0, 0.0f, nullptr };
 cvar_t infiniteAmmo          = { "mp_infinite_ammo", "0", FCVAR_SERVER, 0.0f, nullptr };
 cvar_t infiniteGrenades      = { "mp_infinite_grenades", "0", FCVAR_SERVER, 0.0f, nullptr };
 cvar_t allowmonsters         = { "mp_allowmonsters", "0", FCVAR_SERVER, 0.0f, nullptr };
@@ -279,6 +280,7 @@ void EXT_FUNC GameDLLInit()
 	CVAR_REGISTER(&displaysoundlist);
 	CVAR_REGISTER(&timelimit);
 	CVAR_REGISTER(&friendlyfire);
+	CVAR_REGISTER(&entity_gc);
 
 #ifdef BUILD_LATEST
 	CVAR_REGISTER(&infiniteAmmo);

--- a/regamedll/dlls/game.h
+++ b/regamedll/dlls/game.h
@@ -60,6 +60,7 @@ extern cvar_t fadetoblack;
 extern cvar_t fragsleft;
 extern cvar_t timeleft;
 extern cvar_t friendlyfire;
+extern cvar_t entity_gc;
 extern cvar_t infiniteAmmo;
 extern cvar_t infiniteGrenades;
 extern cvar_t allowmonsters;

--- a/regamedll/dlls/util.cpp
+++ b/regamedll/dlls/util.cpp
@@ -592,7 +592,82 @@ void UTIL_ScreenFade(CBaseEntity *pEntity, const Vector &color, float fadeTime, 
 	UTIL_ScreenFadeWrite(fade, pEntity);
 }
 
-void UTIL_HudMessage(CBaseEntity *pEntity, const hudtextparms_t &textparms, const char *pMessage)
+CHudMessageQueue g_HudQueue;
+
+CHudMessageQueue::CHudMessageQueue() {
+	Reset();
+}
+
+void CHudMessageQueue::Reset() {
+	for (int i = 0; i < 33; i++) {
+		for (int j = 0; j < NUM_HUD_CHANNELS; j++) {
+			m_players[i].channelFreeTime[j] = 0.0f;
+		}
+		for (int j = 0; j < MAX_HUD_QUEUE; j++) {
+			m_players[i].messages[j].inUse = false;
+		}
+	}
+}
+
+void CHudMessageQueue::QueueMessage(int client, const hudtextparms_t &textparms, const char *pMessage) {
+	if (client < 1 || client >= 33) return;
+
+	int freeSlot = -1;
+	for (int i = 0; i < MAX_HUD_QUEUE; i++) {
+		if (!m_players[client].messages[i].inUse) {
+			freeSlot = i;
+			break;
+		}
+	}
+
+	if (freeSlot == -1) {
+		return;
+	}
+
+	m_players[client].messages[freeSlot].textparms = textparms;
+	Q_strlcpy(m_players[client].messages[freeSlot].message, pMessage, sizeof(m_players[client].messages[freeSlot].message));
+	m_players[client].messages[freeSlot].inUse = true;
+}
+
+void CHudMessageQueue::Think() {
+	float currentTime = gpGlobals->time;
+	
+	for (int i = 1; i <= gpGlobals->maxClients; i++) {
+		CBaseEntity *pPlayer = UTIL_PlayerByIndex(i);
+		if (!pPlayer || !pPlayer->IsNetClient())
+			continue;
+
+		for (int j = 0; j < MAX_HUD_QUEUE; j++) {
+			if (!m_players[i].messages[j].inUse)
+				continue;
+			
+			hudtextparms_t parms = m_players[i].messages[j].textparms;
+			
+			int targetChannel = parms.channel - 1; 
+			if (parms.channel <= 0 || parms.channel > NUM_HUD_CHANNELS) {
+				int bestChannel = 0;
+				float oldestTime = m_players[i].channelFreeTime[0];
+				for (int c = 1; c < NUM_HUD_CHANNELS; c++) {
+					if (m_players[i].channelFreeTime[c] < oldestTime) {
+						oldestTime = m_players[i].channelFreeTime[c];
+						bestChannel = c;
+					}
+				}
+				targetChannel = bestChannel;
+				parms.channel = bestChannel + 1;
+			}
+			
+			if (currentTime >= m_players[i].channelFreeTime[targetChannel]) {
+				UTIL_SendHudMessage(pPlayer, parms, m_players[i].messages[j].message);
+				m_players[i].channelFreeTime[targetChannel] = currentTime + parms.fadeinTime + parms.holdTime + parms.fadeoutTime + 0.2f;
+				
+				m_players[i].messages[j].inUse = false;
+			}
+		}
+	}
+}
+
+void UTIL_SendHudMessage(CBaseEntity *pEntity, const hudtextparms_t &textparms, const char *pMessage)
 {
 	if (!pEntity || !pEntity->IsNetClient())
 		return;
@@ -634,6 +709,14 @@ void UTIL_HudMessage(CBaseEntity *pEntity, const hudtextparms_t &textparms, cons
 			}
 		}
 	MESSAGE_END();
+}
+
+void UTIL_HudMessage(CBaseEntity *pEntity, const hudtextparms_t &textparms, const char *pMessage)
+{
+	if (!pEntity || !pEntity->IsNetClient())
+		return;
+
+	g_HudQueue.QueueMessage(pEntity->entindex(), textparms, pMessage);
 }
 
 void UTIL_HudMessageAll(const hudtextparms_t &textparms, const char *pMessage)

--- a/regamedll/dlls/util.cpp
+++ b/regamedll/dlls/util.cpp
@@ -658,7 +658,7 @@ void CHudMessageQueue::Think() {
 			}
 			
 			if (currentTime >= m_players[i].channelFreeTime[targetChannel]) {
-				UTIL_SendHudMessage(pPlayer, parms, m_players[i].messages[j].message);
+				UTIL_HudMessage(pPlayer, parms, m_players[i].messages[j].message);
 				m_players[i].channelFreeTime[targetChannel] = currentTime + parms.fadeinTime + parms.holdTime + parms.fadeoutTime + 0.2f;
 				
 				m_players[i].messages[j].inUse = false;
@@ -667,56 +667,54 @@ void CHudMessageQueue::Think() {
 	}
 }
 
-void UTIL_SendHudMessage(CBaseEntity *pEntity, const hudtextparms_t &textparms, const char *pMessage)
-{
-	if (!pEntity || !pEntity->IsNetClient())
-		return;
-
-	MESSAGE_BEGIN(MSG_ONE, SVC_TEMPENTITY, nullptr, pEntity->edict());
-		WRITE_BYTE(TE_TEXTMESSAGE);
-		WRITE_BYTE(textparms.channel & 0xFF);
-		WRITE_SHORT(FixedSigned16(textparms.x, (1<<13)));
-		WRITE_SHORT(FixedSigned16(textparms.y, (1<<13)));
-		WRITE_BYTE(textparms.effect);
-		WRITE_BYTE(textparms.r1);
-		WRITE_BYTE(textparms.g1);
-		WRITE_BYTE(textparms.b1);
-		WRITE_BYTE(textparms.a1);
-		WRITE_BYTE(textparms.r2);
-		WRITE_BYTE(textparms.g2);
-		WRITE_BYTE(textparms.b2);
-		WRITE_BYTE(textparms.a2);
-		WRITE_SHORT(FixedUnsigned16(textparms.fadeinTime, (1<<8)));
-		WRITE_SHORT(FixedUnsigned16(textparms.fadeoutTime, (1<<8)));
-		WRITE_SHORT(FixedUnsigned16(textparms.holdTime, (1<<8)));
-
-		if (textparms.effect == 2)
-			WRITE_SHORT(FixedUnsigned16(textparms.fxTime, (1<<8)));
-
-		if (!pMessage)
-			WRITE_STRING(" ");
-		else
-		{
-			if (Q_strlen(pMessage) >= 512)
-			{
-				char tmp[512];
-				Q_strlcpy(tmp, pMessage);
-				WRITE_STRING(tmp);
-			}
-			else
-			{
-				WRITE_STRING(pMessage);
-			}
-		}
-	MESSAGE_END();
-}
-
 void UTIL_HudMessage(CBaseEntity *pEntity, const hudtextparms_t &textparms, const char *pMessage)
 {
 	if (!pEntity || !pEntity->IsNetClient())
 		return;
 
-	g_HudQueue.QueueMessage(pEntity->entindex(), textparms, pMessage);
+	MESSAGE_BEGIN(MSG_ONE, SVC_TEMPENTITY, nullptr, pEntity->edict());
+	WRITE_BYTE(TE_TEXTMESSAGE);
+	WRITE_BYTE(textparms.channel & 0xFF);
+
+	WRITE_SHORT(FixedSigned16(textparms.x, 1 << 13));
+	WRITE_SHORT(FixedSigned16(textparms.y, 1 << 13));
+	WRITE_BYTE(textparms.effect);
+
+	WRITE_BYTE(textparms.r1);
+	WRITE_BYTE(textparms.g1);
+	WRITE_BYTE(textparms.b1);
+	WRITE_BYTE(textparms.a1);
+
+	WRITE_BYTE(textparms.r2);
+	WRITE_BYTE(textparms.g2);
+	WRITE_BYTE(textparms.b2);
+	WRITE_BYTE(textparms.a2);
+
+	WRITE_SHORT(FixedUnsigned16(textparms.fadeinTime, 1 << 8));
+	WRITE_SHORT(FixedUnsigned16(textparms.fadeoutTime, 1 << 8));
+	WRITE_SHORT(FixedUnsigned16(textparms.holdTime, 1 << 8));
+
+	if (textparms.effect == 2)
+		WRITE_SHORT(FixedUnsigned16(textparms.fxTime, 1 << 8));
+
+	if (!pMessage)
+	{
+		WRITE_STRING(" ");
+	}
+	else
+	{
+		if (Q_strlen(pMessage) >= 512)
+		{
+			char tmp[512];
+			Q_strlcpy(tmp, pMessage);
+			WRITE_STRING(tmp);
+		}
+		else
+		{
+			WRITE_STRING(pMessage);
+		}
+	}
+	MESSAGE_END();
 }
 
 void UTIL_HudMessageAll(const hudtextparms_t &textparms, const char *pMessage)

--- a/regamedll/dlls/util.h
+++ b/regamedll/dlls/util.h
@@ -227,8 +227,39 @@ void UTIL_ScreenFadeBuild(ScreenFade &fade, const Vector &color, float fadeTime,
 void UTIL_ScreenFadeWrite(const ScreenFade &fade, CBaseEntity *pEntity);
 void UTIL_ScreenFadeAll(const Vector &color, float fadeTime, float fadeHold, int alpha, int flags);
 void UTIL_ScreenFade(CBaseEntity *pEntity, const Vector &color, float fadeTime, float fadeHold = 0.0f, int alpha = 0, int flags = 0);
+// ----------------------------------------------------
+// Native HUD Messages Queue
+// ----------------------------------------------------
+#define MAX_HUD_QUEUE 10
+#define NUM_HUD_CHANNELS 4
+
+struct QueuedHudMessage_t {
+	hudtextparms_t textparms;
+	char message[512];
+	bool inUse;
+};
+
+class CHudMessageQueue {
+public:
+	CHudMessageQueue();
+
+	void QueueMessage(int client, const hudtextparms_t &textparms, const char *pMessage);
+	void Think();
+	void Reset();
+
+private:
+	struct PlayerHudQueue {
+		QueuedHudMessage_t messages[MAX_HUD_QUEUE];
+		float channelFreeTime[NUM_HUD_CHANNELS];
+	};
+	PlayerHudQueue m_players[33];
+};
+
+extern CHudMessageQueue g_HudQueue;
+
 void UTIL_HudMessage(CBaseEntity *pEntity, const hudtextparms_t &textparms, const char *pMessage);
 void UTIL_HudMessageAll(const hudtextparms_t &textparms, const char *pMessage);
+void UTIL_SendHudMessage(CBaseEntity *pEntity, const hudtextparms_t &textparms, const char *pMessage);
 void UTIL_ClientPrintAll(int msg_dest, const char *msg_name, const char *param1 = nullptr, const char *param2 = nullptr, const char *param3 = nullptr, const char *param4 = nullptr);
 void ClientPrint(entvars_t *client, int msg_dest, const char *msg_name, const char *param1 = nullptr, const char *param2 = nullptr, const char *param3 = nullptr, const char *param4 = nullptr);
 void UTIL_Log(const char *fmt, ...);

--- a/regamedll/dlls/util.h
+++ b/regamedll/dlls/util.h
@@ -259,7 +259,6 @@ extern CHudMessageQueue g_HudQueue;
 
 void UTIL_HudMessage(CBaseEntity *pEntity, const hudtextparms_t &textparms, const char *pMessage);
 void UTIL_HudMessageAll(const hudtextparms_t &textparms, const char *pMessage);
-void UTIL_SendHudMessage(CBaseEntity *pEntity, const hudtextparms_t &textparms, const char *pMessage);
 void UTIL_ClientPrintAll(int msg_dest, const char *msg_name, const char *param1 = nullptr, const char *param2 = nullptr, const char *param3 = nullptr, const char *param4 = nullptr);
 void ClientPrint(entvars_t *client, int msg_dest, const char *msg_name, const char *param1 = nullptr, const char *param2 = nullptr, const char *param3 = nullptr, const char *param4 = nullptr);
 void UTIL_Log(const char *fmt, ...);

--- a/regamedll/public/regamedll/regamedll_api.h
+++ b/regamedll/public/regamedll/regamedll_api.h
@@ -856,6 +856,7 @@ public:
 	virtual struct AmmoInfoStruct *GetAmmoInfoEx(const char *ammoName) = 0;
 	virtual bool BGetICSEntity(const char *pchVersion) const = 0;
 	virtual bool BGetIGameRules(const char *pchVersion) const = 0;
+	virtual void QueueHudMessage(int client, const struct hudtextparms_s &textparms, const char *pMessage) = 0;
 };
 
 #define VRE_GAMEDLL_API_VERSION "VRE_GAMEDLL_API_VERSION001"


### PR DESCRIPTION
This PR introduces an intelligent Garbage Collector to prevent the notorious ED_Alloc: no free edicts server crash.

In heavy mods like Zombie Plague or servers with high drop rates, the engine can easily hit the entity limit due to excessive dropped weapons, shields, and gibs on the ground. When that happens, the server crashes instantly.

What this does:

* Adds a new CVAR `mp_entity_gc` (enabled by default) to control the system.
* Actively monitors the current entity count in `StartFrame`.
* If the server gets dangerously close to the limit (less than 100 free edicts), the GC kicks in and safely cleans up the oldest disposable entities (`weaponbox`, `weapon_shield`, and `gib`) to free up slots.
* Safe: C4 bombs are explicitly protected. They will never be deleted by the GC, even if they are inside a dropped weaponbox.

This is a massive stability improvement for custom and heavily modded servers!
