### PR TITLE
cmake: remove duplicate -Wl,-z,notext flags introduced in #1177

### DIFF
--- a/regamedll/CMakeLists.txt
+++ b/regamedll/CMakeLists.txt
@@ -426,21 +426,15 @@ set_target_properties(regamedll PROPERTIES
 
 if (XASH_COMPAT)
 	if (CMAKE_SYSTEM_NAME STREQUAL "Android")
-		set(LINK_FLAGS "${LINK_FLAGS} -Wl,-z,notext")
-
-set_target_properties(regamedll PROPERTIES
+		set_target_properties(regamedll PROPERTIES
 			OUTPUT_NAME server)
 	else()
-		set(LINK_FLAGS "${LINK_FLAGS} -Wl,-z,notext")
-
-set_target_properties(regamedll PROPERTIES
+		set_target_properties(regamedll PROPERTIES
 			PREFIX ""
 			OUTPUT_NAME cs${POSTFIX})
 	endif()
 else()
-	set(LINK_FLAGS "${LINK_FLAGS} -Wl,-z,notext")
-
-set_target_properties(regamedll PROPERTIES
+	set_target_properties(regamedll PROPERTIES
 		OUTPUT_NAME cs
 		PREFIX ""
 		POSITION_INDEPENDENT_CODE OFF)


### PR DESCRIPTION
PR #1177 added `-Wl,-z,notext` unconditionally before the first `set_target_properties` call, which is correct and sufficient. However, the same flag was also prepended to `LINK_FLAGS` inside each of the three `set_target_properties` branches (Android, non-Android Xash, non-Xash), causing it to be appended to `LINK_FLAGS` four times total.

This PR removes the three redundant copies, keeping only the single unconditional addition.